### PR TITLE
Update to consistent usage of vertical bar in readme

### DIFF
--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -24,14 +24,14 @@ const Battery = wrapIcon({ IconClass: _Battery });
 
 <div style="overflow: auto">
 
-| Prop Name | Description                           | Type                                               | Required | Default             |
-| --------- | ------------------------------------- | -------------------------------------------------- | -------- | ------------------- |
-| value     | The value shown below the icon        | `string`\|`number`                                 | yes      |                     |
-| IconClass | A component to render for the icon    | `React.Component<{ size: number, color: string }>` | no       |                     |
-| units     | The units for the supplied value      | `string`                                           | no       |                     |
-| prefix    | If true, shows units before the value | `boolean`                                          | no       | false               |
-| fontSize  | The size of the font for the value    | keyof [`theme.sizes`](./Theme.md)                  | no       | 'medium'            |
-| color     | The color used for the text elements  | `string`                                           | no       | `theme.colors.text` |
-| theme     | Theme partial for default styling     | `Theme`                               | no       |                     |
+| Prop Name | Description                           | Type                                                 | Required | Default             |
+| --------- | ------------------------------------- | ---------------------------------------------------- | -------- | ------------------- |
+| value     | The value shown below the icon        | `string` \| `number`                                 | yes      |                     |
+| IconClass | A component to render for the icon    | `React.Component<{ size: number, color: string }>`   | no       |                     |
+| units     | The units for the supplied value      | `string`                                             | no       |                     |
+| prefix    | If true, shows units before the value | `boolean`                                            | no       | false               |
+| fontSize  | The size of the font for the value    | keyof [`theme.sizes`](./Theme.md)                    | no       | 'medium'            |
+| color     | The color used for the text elements  | `string`                                             | no       | `theme.colors.text` |
+| theme     | Theme partial for default styling     | `Theme`                                              | no       |                     |
 
 </div>

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -28,20 +28,20 @@ The following props can be set at any level in the drawer hierarchy (`<Drawer>`,
 
 <div style="overflow: auto;">
 
-| Name                      | Description                                               | Type                  | Required | Default                                                      |
-| ------------------------- | --------------------------------------------------------- | --------------------- | -------- | ------------------------------------------------------------ |
-| activeItem                | ItemID of the currently selected item                     | `string`              | no       |                                                              |
-| activeItemBackgroundColor | Background color for the 'active' item                    | `string`              | no       | varies for light/dark theme                                  |
-| activeItemBackgroundShape | shape of the active item background                       | `'round'`\|`'square'` | no       | round                                                        |
-| activeItemFontColor       | Font color for the 'active' item                          | `string`              | no       | varies for light/dark theme                                  |
-| activeItemIconColor       | Icon color for the 'active' item                          | `string`              | no       | varies for light/dark theme                                  |
-| chevron                   | Whether to have chevrons for all menu items               | `boolean`             | no       | false                                                        |
-| collapseIcon              | Icon used to collapse drawer                              | `JSX.Element`         | no       | `expandIcon` rotated 180 degrees                             |
-| divider                   | Whether to show a line between all items                  | `boolean`             | no       | true                                                         |
-| expandIcon                | Icon used to expand drawer                                | `JSX.Element`         | no       | `expand-more` at top-level, `arrow-drop-down` otherwise |
-| hidePadding               | Whether to hide the paddings reserved for menu item icons | `boolean`             | no       | true                                                         |
-| itemFontColor             | The color used for the item text                          | `string`              | no       |                                                              |
-| itemIconColor             | The color used for the icon                               | `string`              | no       |                                                              |
+| Name                      | Description                                               | Type                    | Required | Default                                                      |
+| ------------------------- | --------------------------------------------------------- | ----------------------- | -------- | ------------------------------------------------------------ |
+| activeItem                | ItemID of the currently selected item                     | `string`                | no       |                                                              |
+| activeItemBackgroundColor | Background color for the 'active' item                    | `string`                | no       | varies for light/dark theme                                  |
+| activeItemBackgroundShape | shape of the active item background                       | `'round'` \| `'square'` | no       | round                                                        |
+| activeItemFontColor       | Font color for the 'active' item                          | `string`                | no       | varies for light/dark theme                                  |
+| activeItemIconColor       | Icon color for the 'active' item                          | `string`                | no       | varies for light/dark theme                                  |
+| chevron                   | Whether to have chevrons for all menu items               | `boolean`               | no       | false                                                        |
+| collapseIcon              | Icon used to collapse drawer                              | `JSX.Element`           | no       | `expandIcon` rotated 180 degrees                             |
+| divider                   | Whether to show a line between all items                  | `boolean`               | no       | true                                                         |
+| expandIcon                | Icon used to expand drawer                                | `JSX.Element`           | no       | `expand-more` at top-level, `arrow-drop-down` otherwise      |
+| hidePadding               | Whether to hide the paddings reserved for menu item icons | `boolean`               | no       | true                                                         |
+| itemFontColor             | The color used for the item text                          | `string`                | no       |                                                              |
+| itemIconColor             | The color used for the icon                               | `string`                | no       |                                                              |
 
 </div>
 

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -30,6 +30,6 @@ const Battery = wrapIcon({ IconClass: _Battery });
 | iconSize    | The size of the primary icon (100-200) | `number`                                           | no       | 100     |
 | iconColor   | The color of the primary icon          | `string`                                           | no       | `text`  |
 | actions     | Additional components to render below  | `JSX.Element`                                      | no       |         |
-| theme       | Theme partial for default styling      | `Theme`                               | no       |         |
+| theme       | Theme partial for default styling      | `Theme`                                            | no       |         |
 
 </div>

--- a/docs/Header.md
+++ b/docs/Header.md
@@ -40,7 +40,7 @@ const MoreIcon = wrapIcon({IconClass: Icon, name:'more-vert'});
 | fontColor        | The color used for the text             | `string`              | no       | `theme.colors.onPrimary` |
 | backgroundImage  | An image to display in the header       | `ImageSourcePropType` | no       |                          |
 | searchableConfig | Configuration for search behavior       | `SearchableConfig`    | no       |                          |
-| theme            | Theme partial for default styling       | `Theme`  | no       |                          |
+| theme            | Theme partial for default styling       | `Theme`               | no       |                          |
 
 </div>
 

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -39,12 +39,12 @@ const Battery = wrapIcon({ IconClass: _Battery });
 | iconColor           | The color of the primary icon           | `string`                                           | no       | `text`                 |
 | iconBackgroundColor | The color behind the primary icon       | `string`                                           | no       | `theme.colors.surface` |
 | fontSize            | The text size for the value line        | keyof [`theme.sizes`](./Theme.md)                  | no       | 'large'                |
-| value               | The value for the channel               | `string`\|`number`                                 | no       |                        |
+| value               | The value for the channel               | `string` \| `number`                               | no       |                        |
 | ValueIconClass      | The icon to show inline with the value  | `React.Component<{ size: number, color: string }>` | no       |                        |
 | valueColor          | Text color for the value line           | `string`                                           | no       | `text`                 |
 | units               | Text to show after the value            | `string`                                           | no       |                        |
 | onPress             | A function to execute when clicked      | `function`                                         | no       |                        |
-| theme               | Theme partial for default styling       | `Theme`                               | no       |                        |
+| theme               | Theme partial for default styling       | `Theme`                                            | no       |                        |
 
 </div>
 

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -35,7 +35,7 @@ You can also supply an array of items that will be displayed as a character-sepa
 | Prop Name         | Description                            | Type                                               | Required | Default        |
 | ----------------- | -------------------------------------- | -------------------------------------------------- | -------- | -------------- |
 | title             | The text to show on the first line     | `string`                                           | yes      |                |
-| subtitle          | The text to show on the second line    | `string`\|`Array<React.ReactNode>`                 | no       |                |
+| subtitle          | The text to show on the second line    | `string` \| `Array<React.ReactNode>`               | no       |                |
 | subtitleSeparator | Separator character for subtitle       | `string`                                           | no       | '·' ('\u00B7') |
 | IconClass         | A component to render for the icon     | `React.Component<{ size: number, color: string }>` | no       |                |
 | iconColor         | The color of the primary icon          | `string`                                           | no       |                |
@@ -43,12 +43,12 @@ You can also supply an array of items that will be displayed as a character-sepa
 | avatar            | Show colored background for icon       | `boolean`                                          | no       | false          |
 | chevron           | Add a chevron icon on the right        | `boolean`                                          | no       | false          |
 | dense             | Smaller height row with less padding   | `boolean`                                          | no       | false          |
-| divider           | Show a row separator below the row     | `'full'`\|`'partial'`                              | no       |                |
+| divider           | Show a row separator below the row     | `'full'` \| `'partial'`                            | no       |                |
 | rightComponent    | Component to render on the right side  | `JSX.Element`                                      | no       |                |
 | statusColor       | Status stripe and icon color           | `string`                                           | no       |                |
 | fontColor         | Title text color                       | `string`                                           | no       |                |
 | backgroundColor   | The color used for the background      | `string`                                           | no       |                |
 | onPress           | A function to execute when clicked     | `function`                                         | no       |                |
-| theme             | Theme partial for default styling      | `Theme`                               | no       |                |
+| theme             | Theme partial for default styling      | `Theme`                                            | no       |                |
 
 </div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 We currently have the following components available for React Native applications:
 
 -   [Channel Value](https://github.com/pxblue/react-native-component-library/blob/dev/docs/ChannelValue.md)
+-   [Drawer](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Drawer.md)
 -   [Empty State](https://github.com/pxblue/react-native-component-library/blob/dev/docs/EmptyState.md)
 -   [Header](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Header.md)
 -   [Hero & Hero Banner](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Hero.md)

--- a/docs/ScoreCard.md
+++ b/docs/ScoreCard.md
@@ -57,7 +57,7 @@ const MoreIcon = wrapIcon({ IconClass: MatIcon, name: 'more-vert' });
 | badge                 | The component to render in the callout area | `React.Component`     | no       |                          |
 | badgeOffset           | Vertical offset for the badge component     | `number`              | no       |                          |
 | actionRow             | Component to render for the footer          | `React.Component`     | no       |                          |
-| theme                 | Theme partial for default styling           | `Theme`  | no       |                          |
+| theme                 | Theme partial for default styling           | `Theme`               | no       |                          |
 
 </div>
 

--- a/docs/Typography.md
+++ b/docs/Typography.md
@@ -39,6 +39,6 @@ All typography components in this library share a common API.
 | font      | The font style (from the theme)     | keyof [`theme.fonts`](./Theme.md)  | no       |         |
 | fontSize  | The font size (from the theme)      | keyof [`theme.sizes`](./Theme.md)  | no       |         |
 | color     | The font color (from theme palette) | keyof [`theme.colors`](./Theme.md) | no       | 'text'  |
-| theme     | Theme partial for default styling   | `Theme`               | no       |         |
+| theme     | Theme partial for default styling   | `Theme`                            | no       |         |
 
 </div>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
For PXBLUE-1355.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Update to consistent usage of vertical bar in readme tables
- Add missing link for Drawer