### PR TITLE
Downgrade version of react-native-safe-area-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ yarn add @pxblue/react-native-components
 
 > **NOTE**: This install command will install the package from NPM. If you are a PX Blue developer working with components locally, you will want to follow the manual linking instructions - see below.
 
+### Peer Dependencies
+This library has a few dependencies that you will need to install in your project in order to work correctly. To install them, you can run the following command in your project root:
+
+```shell
+npm install --save react-native-paper@^3.10.1 react-native-safe-area-context@~0.7.0 react-native-vector-icons@^6.6.0
+// or 
+yarn add react-native-paper@^3.10.1 react-native-safe-area-context@~0.7.0 react-native-vector-icons@^6.6.0
+```
+> NOTE: We require an older version of react-native-safe-area-context (0.7.x instead of 3.x.x) to maintain compatibility with Expo projects.
+
 ## Building the Library
 
 To work with this library, first clone down the repository and install dependencies:

--- a/components/package.json
+++ b/components/package.json
@@ -26,7 +26,7 @@
     "react": "^16.8.6",
     "react-native": "^0.60.4",
     "react-native-paper": "^3.10.1",
-    "react-native-safe-area-context": "^3.0.2",
+    "react-native-safe-area-context": "~0.7.0",
     "react-native-vector-icons": "^6.6.0"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
     "react-native": "^0.59.8",
     "react-native-elements": "^1.2.6",
     "react-native-paper": "^3.10.1",
-    "react-native-safe-area-context": "^3.0.2",
+    "react-native-safe-area-context": "~0.7.0",
     "react-native-svg": "^9.6.1",
     "react-native-vector-icons": "^6.6.0",
     "react-test-renderer": "^16.8.6",

--- a/components/src/core/drawer/drawer-header.tsx
+++ b/components/src/core/drawer/drawer-header.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { H6, Subtitle1 } from '../typography';
 import { Divider, Theme, useTheme } from 'react-native-paper';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSafeArea } from 'react-native-safe-area-context';
 import { EdgeInsets } from '../__types__';
 
 const makeStyles = (props: DrawerHeaderProps, theme: Theme, insets: EdgeInsets): any =>
@@ -108,7 +108,7 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
         style,
     } = props;
     const theme = useTheme(themeOverride);
-    const insets = useSafeAreaInsets();
+    const insets = useSafeArea();
     const defaultStyles = makeStyles(props, theme, insets);
 
     const getIcon = useCallback((): ReactNode => <View style={[defaultStyles.icon, styles.icon]}>{icon}</View>, [

--- a/components/src/core/drawer/drawer-header.tsx
+++ b/components/src/core/drawer/drawer-header.tsx
@@ -43,7 +43,7 @@ const makeStyles = (props: DrawerHeaderProps, theme: Theme, insets: EdgeInsets):
         },
         subtitle: {
             color: props.fontColor || theme.colors.surface,
-            lineHeight: 15,
+            lineHeight: 16,
             marginTop: -2,
         },
         backgroundImageWrapper: {

--- a/components/src/core/drawer/drawer.tsx
+++ b/components/src/core/drawer/drawer.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useSafeArea } from 'react-native-safe-area-context';
 import { DrawerInheritableProps, inheritDrawerProps } from './inheritable-types';
 import MatIcon from 'react-native-vector-icons/MaterialIcons';
 import { Theme, useTheme } from 'react-native-paper';
@@ -39,7 +39,7 @@ export const Drawer: React.FC<DrawerProps> = (props) => {
         expandIcon = <MatIcon name={'expand-more'} size={24} color={theme.colors.text} />,
         collapseIcon = <MatIcon name={'expand-less'} size={24} color={theme.colors.text} />,
     } = props;
-    const insets = useSafeAreaInsets();
+    const insets = useSafeArea();
     const defaultStyles = makeStyles(props, theme, insets);
 
     const findChildByType = useCallback(

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -6003,10 +6003,10 @@ react-native-ratings@^6.3.0:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-native-safe-area-context@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-3.0.2.tgz#95dd7e56bc89bcc4f3f7bb5fada30c98420328b2"
-  integrity sha512-x3yVMsxwe9GyvIkv0Q5jy2CWYN7VO0/CJTFGG5kSiMo8FFTQJbWtuWGANFqxDzEH5NEV7/SfK+qTgAh931KyUw==
+react-native-safe-area-context@~0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
+  integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"

--- a/demos/showcase/ios/Podfile.lock
+++ b/demos/showcase/ios/Podfile.lock
@@ -233,7 +233,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
   - React-jsinspector (0.62.2)
-  - react-native-safe-area-context (2.0.3):
+  - react-native-safe-area-context (0.7.3):
     - React
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
@@ -473,7 +473,7 @@ SPEC CHECKSUMS:
   React-jsi: b6dc94a6a12ff98e8877287a0b7620d365201161
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
-  react-native-safe-area-context: 14c793e8b0bfe51e74dcdbe75dd14ee7498b88b8
+  react-native-safe-area-context: e200d4433aba6b7e60b52da5f37af11f7a0b0392
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71

--- a/demos/showcase/package.json
+++ b/demos/showcase/package.json
@@ -29,7 +29,7 @@
         "react-native-gesture-handler": "^1.6.1",
         "react-native-paper": "^3.10.1",
         "react-native-reanimated": "^1.9.0",
-        "react-native-safe-area-context": "^2.0.3",
+        "react-native-safe-area-context": "~0.7.0",
         "react-native-screens": "^2.8.0",
         "react-native-svg": "^12.1.0",
         "react-native-vector-icons": "^6.6.0"

--- a/demos/showcase/yarn.lock
+++ b/demos/showcase/yarn.lock
@@ -7135,10 +7135,10 @@ react-native-reanimated@^1.9.0:
   dependencies:
     fbjs "^1.0.0"
 
-react-native-safe-area-context@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-2.0.3.tgz#d89b60336ea2a1e9e2ff64fcac7b226aea0af370"
-  integrity sha512-KMYfJNLyPEFnYbpZiViqa9wHqVXZdZTebhs4tGER8YPvLRc4Qp7mUSfhDVnlNG/xG1denO1ehTAZQZ1fogxJeg==
+react-native-safe-area-context@~0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
+  integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"

--- a/demos/storybook/ios/Podfile.lock
+++ b/demos/storybook/ios/Podfile.lock
@@ -233,7 +233,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
   - React-jsinspector (0.62.2)
-  - react-native-safe-area-context (3.0.2):
+  - react-native-safe-area-context (0.7.3):
     - React
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
@@ -453,7 +453,7 @@ SPEC CHECKSUMS:
   React-jsi: b6dc94a6a12ff98e8877287a0b7620d365201161
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
-  react-native-safe-area-context: b11a34881faac509cad5578726c98161ad4d275c
+  react-native-safe-area-context: e200d4433aba6b7e60b52da5f37af11f7a0b0392
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71

--- a/demos/storybook/package.json
+++ b/demos/storybook/package.json
@@ -22,7 +22,7 @@
         "react-native": "0.62.2",
         "react-native-elements": "^2.0.1",
         "react-native-paper": "^3.10.1",
-        "react-native-safe-area-context": "^3.0.2",
+        "react-native-safe-area-context": "~0.7.0",
         "react-native-svg": "^12.1.0",
         "react-native-svg-transformer": "^0.14.3",
         "react-native-vector-icons": "^6.6.0"

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -11005,10 +11005,10 @@ react-native-ratings@^7.2.0:
     lodash "^4.17.4"
     prop-types "^15.5.10"
 
-react-native-safe-area-context@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.0.2.tgz#95dd7e56bc89bcc4f3f7bb5fada30c98420328b2"
-  integrity sha512-x3yVMsxwe9GyvIkv0Q5jy2CWYN7VO0/CJTFGG5kSiMo8FFTQJbWtuWGANFqxDzEH5NEV7/SfK+qTgAh931KyUw==
+react-native-safe-area-context@~0.7.0:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-0.7.3.tgz#ad6bd4abbabe195332c53810e4ce5851eb21aa2a"
+  integrity sha512-9Uqu1vlXPi+2cKW/CW6OnHxA76mWC4kF3wvlqzq4DY8hn37AeiXtLFs2WkxH4yXQRrnJdP6ivc65Lz+MqwRZAA==
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/react-native-components",
-  "version": "3.0.0",
+  "version": "3.0.0-beta.3",
   "author": "pxblue <pxblue@eaton.com>",
   "description": "Reusable React Native components for PX Blue applications",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pxblue/react-native-components",
-  "version": "3.0.0-beta.2",
+  "version": "3.0.0",
   "author": "pxblue <pxblue@eaton.com>",
   "description": "Reusable React Native components for PX Blue applications",
   "repository": {
@@ -52,7 +52,7 @@
     "react": "^16.8.6",
     "react-native": "^0.60.4",
     "react-native-paper": "^3.10.1",
-    "react-native-safe-area-context": "^3.0.2",
+    "react-native-safe-area-context": "~0.7.0",
     "react-native-vector-icons": "^6.6.0"
   },
   "files": [


### PR DESCRIPTION

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Drop version of react-native-safe-area-context to 0.7 to maintain Expo compatibility
