### PR TITLE
Set color for the subtitle icon

### DIFF
--- a/demos/storybook/storybook/stories/info-list-item/info-list-item.tsx
+++ b/demos/storybook/storybook/stories/info-list-item/info-list-item.tsx
@@ -82,7 +82,7 @@ storiesOf('InfoListItem', module)
             <InfoListItem
                 title={text('title', 'Test')}
                 IconClass={LeafIcon}
-                subtitle={['4', <Leaf key={'leaf'} width={12} height={12} />, 'leaves']}
+                subtitle={['4', <Leaf key={'leaf'} width={12} height={12} fill={'green'} />, 'leaves']}
                 subtitleSeparator={text('separator', '-')}
             />
         ),


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #49.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- When using the latest version of react-native-svg, there's a bug that requires us to manually set the fill color for icons (no black default anymore).
