### PR TITLE
Tweak a few types

### DIFF
--- a/components/src/core/drawer/drawer-header.tsx
+++ b/components/src/core/drawer/drawer-header.tsx
@@ -113,7 +113,7 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
     const insets = useSafeArea();
     const defaultStyles = makeStyles(props, theme, insets);
 
-    const getIcon = useCallback((): ReactNode => <View style={[defaultStyles.icon, styles.icon]}>{icon}</View>, [
+    const getIcon = useCallback((): JSX.Element => <View style={[defaultStyles.icon, styles.icon]}>{icon}</View>, [
         defaultStyles,
         styles,
     ]);

--- a/components/src/core/drawer/drawer-nav-group.tsx
+++ b/components/src/core/drawer/drawer-nav-group.tsx
@@ -72,7 +72,7 @@ export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
     const defaultStyles = drawerNavGroupStyles;
 
     const getDrawerItemList = useCallback(
-        (item: NavItem | NestedNavItem, depth: number): ReactNode => {
+        (item: NavItem | NestedNavItem, depth: number): JSX.Element => {
             const [expanded, setExpanded] = useState(findID(item, props.activeItem));
 
             // Nested items inherit from the nestedDivider prop if item's divider is unset.

--- a/components/src/core/hero/hero.tsx
+++ b/components/src/core/hero/hero.tsx
@@ -40,9 +40,6 @@ export type HeroProps = ViewProps & {
     label: string;
 
     /** Primary icon */
-    // icon: React.ReactNode;
-
-    /** Primary icon */
     IconClass: ComponentType<{ size: number; color: string }>;
 
     /** Primary icon size */

--- a/demos/storybook/storybook/stories/bucket-view.tsx
+++ b/demos/storybook/storybook/stories/bucket-view.tsx
@@ -59,7 +59,7 @@ storiesOf('BucketView')
                     title={device.name}
                     subtitle={`aquired: ${device.dateAcquired.toUTCString()}`}
                     backgroundColor={white[100]}
-                    color={device.status === 'stopped' ? red[800] : blue[800]}
+                    statusColor={device.status === 'stopped' ? red[800] : blue[800]}
                 />
             )}
             ItemSeparatorComponent={Separator}
@@ -76,7 +76,7 @@ storiesOf('BucketView')
                     <InfoListItem
                         title={device.name}
                         subtitle={`aquired: ${device.dateAcquired.toUTCString()}`}
-                        color={device.status === 'stopped' ? red[800] : blue[800]}
+                        statusColor={device.status === 'stopped' ? red[800] : blue[800]}
                     />
                 </View>
             )}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #15.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
Changes proposed in this Pull Request:
- Update a couple of types

It's worth mentioning that the ReactNode type seems to be less useful in React Native than in React. If you want to support a string or an element, this type doesn't get you there because RN requires all text to be contained in a `<Text>` tag anyway, so it becomes an Element. Supporting the ReactNode type requires extra logic on the other side to test if it's a string and then wrap it in a Text element...more work than it's worth in most cases I think.
