### PR TITLE
Add icon align prop to infolistitem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change Log
 
-## v3.1.1
-
--   Adds `iconAlign` prop to `<InfoListItem>` to align icons left (default), center or right.
-
 ## v3.1.0
 
 -   Added RTL support
@@ -12,6 +8,7 @@
 -   Added new component for `<ListItemTag>` and `<Spacer>`
 -   Upgraded dependencies to latest version of react-native-safe-area-context
     -   To use with an Expo project you'll need to be using v38+ of the Expo SDK
+-   Added `iconAlign` prop to `<InfoListItem>` to align icons left (default), center or right.
 
 ## v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v3.1.1
+
+-   Adds `iconAlign` prop to `<InfoListItem>` to align icons left (default), center or right.
+
 ## v3.1.0
 
 -   Added RTL support

--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -17,6 +17,20 @@ import color from 'color';
 import { renderableSubtitleComponent, withKeys, separate } from './utilities';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 
+type IconAlign = 'left' | 'center' | 'right';
+
+const getIconAlignment = (iconAlign?: IconAlign): 'flex-start' | 'center' | 'flex-end' => {
+    switch (iconAlign) {
+        case 'right':
+            return 'flex-end';
+        case 'center':
+            return 'center';
+        case 'left':
+        default:
+            return 'flex-start';
+    }
+};
+
 const infoListItemStyles = (
     props: InfoListItemProps,
     theme: Theme
@@ -25,6 +39,7 @@ const infoListItemStyles = (
     title: TextStyle;
     subtitle: TextStyle;
     subtitleWrapper: ViewStyle;
+    icon: ViewStyle;
     info: TextStyle;
     infoWrapper: ViewStyle;
     statusStripe: ViewStyle;
@@ -80,6 +95,12 @@ const infoListItemStyles = (
             justifyContent: 'center',
             backgroundColor: props.statusColor || theme.colors.text,
         },
+        icon: {
+            width: 40,
+            justifyContent: 'center',
+            backgroundColor: 'transparent',
+            alignItems: getIconAlignment(props.iconAlign),
+        },
         mainContent: {
             flex: 1,
             paddingHorizontal: 16,
@@ -104,6 +125,9 @@ export type InfoListItemProps = ViewProps & {
 
     /** Specifies whether to show color background around the icon */
     avatar?: boolean;
+
+    /** Icon alignment when avatar prop is set to false */
+    iconAlign?: IconAlign;
 
     /** Component to render to the left of the title */
     IconClass?: ComponentType<{ size: number; color: string }>;
@@ -144,6 +168,7 @@ export type InfoListItemProps = ViewProps & {
         statusStripe?: StyleProp<ViewStyle>;
         iconWrapper?: StyleProp<ViewStyle>;
         avatar?: StyleProp<ViewStyle>;
+        icon?: StyleProp<ViewStyle>;
         mainContent?: StyleProp<ViewStyle>;
         title?: StyleProp<TextStyle>;
         subtitle?: StyleProp<TextStyle>;
@@ -175,6 +200,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         statusColor,
         dense, //eslint-disable-line @typescript-eslint/no-unused-vars
         fontColor, //eslint-disable-line @typescript-eslint/no-unused-vars
+        iconAlign, //eslint-disable-line @typescript-eslint/no-unused-vars
         iconColor,
         backgroundColor, //eslint-disable-line @typescript-eslint/no-unused-vars
         onPress,
@@ -203,7 +229,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (IconClass) {
             return (
-                <View style={avatar ? [defaultStyles.avatar, styles.avatar] : null}>
+                <View style={avatar ? [defaultStyles.avatar, styles.avatar] : [defaultStyles.icon, styles.icon]}>
                     <IconClass size={24} color={getIconColor()} />
                 </View>
             );

--- a/demos/showcase/App.tsx
+++ b/demos/showcase/App.tsx
@@ -182,6 +182,7 @@ export const App: React.FC<AppProps> = ({ navigation }) => {
                     statusColor={PXBColors.orange[500]}
                     divider={'full'}
                     IconClass={Pie}
+                    iconAlign={'center'}
                     hidePadding={false}
                     fontColor={PXBColors.red[500]}
                     rightComponent={<ChannelValue value={15} units={'A'} />}

--- a/demos/storybook/storybook/stories/info-list-item/info-list-item.tsx
+++ b/demos/storybook/storybook/stories/info-list-item/info-list-item.tsx
@@ -31,6 +31,8 @@ storiesOf('InfoListItem', module)
         () => (
             <InfoListItem
                 title={'Info List Item'}
+                // TODO: make this work
+                // iconAlign={select('iconAlign', ['left', 'center', 'right'], 'left')}
                 IconClass={LeafIcon}
                 iconColor={color('iconColor', Colors.green[500])}
                 subtitle={'with an icon'}
@@ -118,6 +120,8 @@ storiesOf('InfoListItem', module)
                 }
                 rightComponent={<ChannelValue value={15} units={'A'} />}
                 avatar={boolean('avatar', false)}
+                // TODO: make this work
+                // iconAlign={select('iconAlign', ['left', 'center', 'right'], 'right')}
                 iconColor={color('iconColor', Colors.green[500])}
                 statusColor={color('statusColor', Colors.blue[700])}
                 fontColor={color('fontColor', Colors.blue[700])}

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -32,43 +32,44 @@ You can also supply an array of items that will be displayed as a character-sepa
 
 <div style="overflow: auto">
 
-| Prop Name         | Description                            | Type                                               | Required | Default        |
-| ----------------- | -------------------------------------- | -------------------------------------------------- | -------- | -------------- |
-| title             | The text to show on the first line     | `string`                                           | yes      |                |
-| subtitle          | The text to show on the second line    | `string` \| `Array<React.ReactNode>`               | no       |                |
-| subtitleSeparator | Separator character for subtitle       | `string`                                           | no       | '·' ('\u00B7') |
-| info              | The text to show on the third line     | `string` \| `Array<React.ReactNode>`               | no       |                |
-| IconClass         | A component to render for the icon     | `React.Component<{ size: number, color: string }>` | no       |                |
-| iconColor         | The color of the primary icon          | `string`                                           | no       |                |
-| hidePadding       | Remove left padding if no icon is used | `boolean`                                          | no       | false          |
-| avatar            | Show colored background for icon       | `boolean`                                          | no       | false          |
-| chevron           | Add a chevron icon on the right        | `boolean`                                          | no       | false          |
-| dense             | Smaller height row with less padding   | `boolean`                                          | no       | false          |
-| divider           | Show a row separator below the row     | `'full'` \| `'partial'`                            | no       |                |
-| rightComponent    | Component to render on the right side  | `JSX.Element`                                      | no       |                |
-| statusColor       | Status stripe and icon color           | `string`                                           | no       |                |
-| fontColor         | Title text color                       | `string`                                           | no       |                |
-| backgroundColor   | The color used for the background      | `string`                                           | no       |                |
-| onPress           | A function to execute when clicked     | `function`                                         | no       |                |
-| theme             | Theme partial for default styling      | `Theme`                                            | no       |                |
+| Prop Name         | Description                                  | Type                                               | Required | Default        |
+| ----------------- | -------------------------------------------- | -------------------------------------------------- | -------- | -------------- |
+| title             | The text to show on the first line           | `string`                                           | yes      |                |
+| subtitle          | The text to show on the second line          | `string` \| `Array<React.ReactNode>`               | no       |                |
+| subtitleSeparator | Separator character for subtitle             | `string`                                           | no       | '·' ('\u00B7') |
+| info              | The text to show on the third line           | `string` \| `Array<React.ReactNode>`               | no       |                |
+| iconAlign         | Icon alignment when `avatar` is set to false | `'left'` \| `'center'` \| `'right'`                | no       | 'left'         |
+| IconClass         | A component to render for the icon           | `React.Component<{ size: number, color: string }>` | no       |                |
+| iconColor         | The color of the primary icon                | `string`                                           | no       |                |
+| hidePadding       | Remove left padding if no icon is used       | `boolean`                                          | no       | false          |
+| avatar            | Show colored background for icon             | `boolean`                                          | no       | false          |
+| chevron           | Add a chevron icon on the right              | `boolean`                                          | no       | false          |
+| dense             | Smaller height row with less padding         | `boolean`                                          | no       | false          |
+| divider           | Show a row separator below the row           | `'full'` \| `'partial'`                            | no       |                |
+| rightComponent    | Component to render on the right side        | `JSX.Element`                                      | no       |                |
+| statusColor       | Status stripe and icon color                 | `string`                                           | no       |                |
+| fontColor         | Title text color                             | `string`                                           | no       |                |
+| backgroundColor   | The color used for the background            | `string`                                           | no       |                |
+| onPress           | A function to execute when clicked           | `function`                                         | no       |                |
+| theme             | Theme partial for default styling            | `Theme`                                            | no       |                |
 
 </div>
-
 
 ### Styles
 
 You can override the internal styles used by PX Blue by passing a `styles` prop. It supports the following keys:
 
-| Name              | Description                                     |
-| ----------------- | ----------------------------------------------- |
-| root              | Styles applied to the root element              |
-| statusStripe      | Styles applied to the status stripe element     |
-| iconWrapper       | Styles applied to the icon wrapper              |
-| infoWrapper      | Styles applied to the info wrapper              |
-| info              | Styles applied to the info text elements        |
-| avatar            | Styles applied to the avatar background         |
-| mainContent       | Styles applied to the main text content wrapper |
-| title             | Styles applied to the title element             |
-| subtitleWrapper   | Styles applied to the subtitle wrapper          |
-| subtitle          | Styles applied to the subtitle text elements    |
-| divider           | Styles applied to the divider element           |
+| Name            | Description                                     |
+| --------------- | ----------------------------------------------- |
+| root            | Styles applied to the root element              |
+| statusStripe    | Styles applied to the status stripe element     |
+| icon            | Styles applied to the icon element              |
+| iconWrapper     | Styles applied to the icon wrapper              |
+| infoWrapper     | Styles applied to the info wrapper              |
+| info            | Styles applied to the info text elements        |
+| avatar          | Styles applied to the avatar background         |
+| mainContent     | Styles applied to the main text content wrapper |
+| title           | Styles applied to the title element             |
+| subtitleWrapper | Styles applied to the subtitle wrapper          |
+| subtitle        | Styles applied to the subtitle text elements    |
+| divider         | Styles applied to the divider element           |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-native-components",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "author": "pxblue <pxblue@eaton.com>",
     "description": "Reusable React Native components for PX Blue applications",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-native-components",
-    "version": "3.1.1",
+    "version": "3.1.0",
     "author": "pxblue <pxblue@eaton.com>",
     "description": "Reusable React Native components for PX Blue applications",
     "repository": {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-1472

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add icon align prop to info list item

#### known issue
- icons sometimes don't get rendered
- storybook does not do the `select` knob properly, so commented out for now

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
`iconAlign={'left'}`
![Screen Shot 2020-08-07 at 1 13 44 PM](https://user-images.githubusercontent.com/8997218/89677218-06a23880-d8bb-11ea-9455-35380893272e.png)

`iconAlign={'center'}`
![Screen Shot 2020-08-07 at 1 14 06 PM](https://user-images.githubusercontent.com/8997218/89677219-06a23880-d8bb-11ea-8a79-311a1ae15a4f.png)

`iconAlign={'right'}`
![Screen Shot 2020-08-07 at 1 14 51 PM](https://user-images.githubusercontent.com/8997218/89677220-073acf00-d8bb-11ea-80ac-1132d45173f6.png)
