### PR TITLE
Update ChannelValue and InfoListItem to use appropriate typography elements

### DIFF
--- a/components/src/core/channel-value/channel-value.tsx
+++ b/components/src/core/channel-value/channel-value.tsx
@@ -1,7 +1,7 @@
 import React, { ComponentType, useCallback } from 'react';
 import { View, StyleSheet, ViewProps, ViewStyle, StyleProp, TextStyle, I18nManager } from 'react-native';
 import { useTheme } from 'react-native-paper';
-import { Body1 } from '../typography';
+import { Body1, Subtitle1 } from '../typography';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 
 const defaultStyles = StyleSheet.create({
@@ -119,9 +119,9 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                 style={[{ color: getColor() }]}
             >
                 {prefixUnits()}
-                <Body1 font={'medium'} fontSize={fontSize} style={[{ color: getColor() }, styles.value]}>
+                <Subtitle1 fontSize={fontSize} style={[{ color: getColor() }, styles.value]}>
                     {value}
-                </Body1>
+                </Subtitle1>
                 {suffixUnits()}
             </Body1>
         </View>

--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useTheme, Divider as PaperDivider } from 'react-native-paper';
-import { Body1 } from '../typography';
+import { Subtitle1 } from '../typography';
 import * as Colors from '@pxblue/colors';
 import color from 'color';
 import { renderableSubtitleComponent, withKeys, separate } from './utilities';
@@ -317,14 +317,9 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
             ) : null}
             {leftComponent}
             <View style={[defaultStyles.mainContent, styles.mainContent]}>
-                <Body1
-                    style={[defaultStyles.title, styles.title]}
-                    numberOfLines={1}
-                    ellipsizeMode={'tail'}
-                    font={'medium'}
-                >
+                <Subtitle1 style={[defaultStyles.title, styles.title]} numberOfLines={1} ellipsizeMode={'tail'}>
                     {title}
-                </Body1>
+                </Subtitle1>
                 <View style={[defaultStyles.subtitleWrapper, styles.subtitleWrapper]}>{getSubtitle()}</View>
                 <View style={[defaultStyles.infoWrapper, styles.infoWrapper]}>{getInfo()}</View>
             </View>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes PXBLUE-1894.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update ChannelValue and InfoListItem to use appropriate typography elements

*note: This story was originally to add a 16px, 600 font-weight typography element but Subtitle1 already takes care of this so I just went through and updated the body1 typographies that were using font-weight style overrides to use subtitle1 instead.
