### PR TITLE
Spread card props on scorecard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v5.0.1 (Unpublished)
+
+### Fixed
+
+-   `<ScoreCard>` component now extends the `<Card>` components from React Native Paper.
+
 ## v5.0.0 (March 30, 2021)
 
 ### Changed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-native-components",
-    "version": "5.0.0",
+    "version": "5.0.1-beta.0",
     "author": "pxblue <pxblue@eaton.com>",
     "description": "Reusable React Native components for PX Blue applications",
     "repository": {

--- a/components/src/core/score-card/score-card.test.tsx
+++ b/components/src/core/score-card/score-card.test.tsx
@@ -11,11 +11,7 @@ describe('ScoreCard', () => {
         describe('when a single string is passed in as headerText', () => {
             let instance: ReactTestInstance;
             beforeEach(() => {
-                instance = TestRenderer.create(
-                    <ScoreCard headerTitle={'Hello'}>
-                        <View />
-                    </ScoreCard>
-                ).root;
+                instance = TestRenderer.create(<ScoreCard headerTitle={'Hello'} />).root;
             });
 
             it('finds a single header text element', () => {
@@ -33,9 +29,7 @@ describe('ScoreCard', () => {
                         headerTitle={'Portland Datacenter Long Name'}
                         headerSubtitle={'6 UPS Devices'}
                         headerInfo={'Attention Required'}
-                    >
-                        <View />
-                    </ScoreCard>
+                    />
                 ).root;
             });
 
@@ -52,9 +46,7 @@ describe('ScoreCard', () => {
             let instance: ReactTestInstance;
             beforeEach(() => {
                 instance = TestRenderer.create(
-                    <ScoreCard headerTitle={'Hello'} actionRow={<View testID={'my-action'} />}>
-                        <View />
-                    </ScoreCard>
+                    <ScoreCard headerTitle={'Hello'} actionRow={<View testID={'my-action'} />} />
                 ).root;
             });
 
@@ -72,9 +64,7 @@ describe('ScoreCard', () => {
                     <ScoreCard
                         headerTitle={'Hello'}
                         badge={<Hero testID={'my-badge'} label={'...'} IconClass={Line} />}
-                    >
-                        <View />
-                    </ScoreCard>
+                    />
                 ).root;
             });
 
@@ -99,9 +89,7 @@ describe('ScoreCard', () => {
                             { icon: Line, onPress: firstCallback },
                             { icon: Line, onPress: secondCallback },
                         ]}
-                    >
-                        <View />
-                    </ScoreCard>
+                    />
                 ).root;
             });
 
@@ -140,9 +128,7 @@ describe('ScoreCard', () => {
                             { icon: Line, onPress: jest.fn() },
                             { icon: Line, onPress: jest.fn() },
                         ]}
-                    >
-                        <View />
-                    </ScoreCard>
+                    />
                 ).root;
             });
 

--- a/components/src/core/score-card/score-card.test.tsx
+++ b/components/src/core/score-card/score-card.test.tsx
@@ -11,7 +11,11 @@ describe('ScoreCard', () => {
         describe('when a single string is passed in as headerText', () => {
             let instance: ReactTestInstance;
             beforeEach(() => {
-                instance = TestRenderer.create(<ScoreCard headerTitle={'Hello'} />).root;
+                instance = TestRenderer.create(
+                    <ScoreCard headerTitle={'Hello'}>
+                        <View />
+                    </ScoreCard>
+                ).root;
             });
 
             it('finds a single header text element', () => {
@@ -29,7 +33,9 @@ describe('ScoreCard', () => {
                         headerTitle={'Portland Datacenter Long Name'}
                         headerSubtitle={'6 UPS Devices'}
                         headerInfo={'Attention Required'}
-                    />
+                    >
+                        <View />
+                    </ScoreCard>
                 ).root;
             });
 
@@ -46,7 +52,9 @@ describe('ScoreCard', () => {
             let instance: ReactTestInstance;
             beforeEach(() => {
                 instance = TestRenderer.create(
-                    <ScoreCard headerTitle={'Hello'} actionRow={<View testID={'my-action'} />} />
+                    <ScoreCard headerTitle={'Hello'} actionRow={<View testID={'my-action'} />}>
+                        <View />
+                    </ScoreCard>
                 ).root;
             });
 
@@ -64,7 +72,9 @@ describe('ScoreCard', () => {
                     <ScoreCard
                         headerTitle={'Hello'}
                         badge={<Hero testID={'my-badge'} label={'...'} IconClass={Line} />}
-                    />
+                    >
+                        <View />
+                    </ScoreCard>
                 ).root;
             });
 
@@ -89,7 +99,9 @@ describe('ScoreCard', () => {
                             { icon: Line, onPress: firstCallback },
                             { icon: Line, onPress: secondCallback },
                         ]}
-                    />
+                    >
+                        <View />
+                    </ScoreCard>
                 ).root;
             });
 
@@ -128,7 +140,9 @@ describe('ScoreCard', () => {
                             { icon: Line, onPress: jest.fn() },
                             { icon: Line, onPress: jest.fn() },
                         ]}
-                    />
+                    >
+                        <View />
+                    </ScoreCard>
                 ).root;
             });
 

--- a/components/src/core/score-card/score-card.tsx
+++ b/components/src/core/score-card/score-card.tsx
@@ -234,9 +234,7 @@ const scoreCardStyles = (
         },
     });
 
-// TODO Extend the Card Props once RNP fixes their type definitions in 4.0.0
-// export type ScoreCardProps = React.ComponentProps<typeof Card> & {
-export type ScoreCardProps = {
+export type ScoreCardProps = React.ComponentProps<typeof Card> & {
     /** Background color of header */
     headerColor?: string;
 
@@ -263,10 +261,6 @@ export type ScoreCardProps = {
 
     /** Background image to render when header is expanded */
     headerBackgroundImage?: ImageSourcePropType;
-
-    // TODO remove this when we extend from the Card Props
-    /** Styles for the root component */
-    style?: StyleProp<ViewStyle>;
 
     /** Style Overrides */
     styles?: {

--- a/components/src/core/score-card/score-card.tsx
+++ b/components/src/core/score-card/score-card.tsx
@@ -234,7 +234,10 @@ const scoreCardStyles = (
         },
     });
 
-export type ScoreCardProps = React.ComponentProps<typeof Card> & {
+export type ScoreCardProps = Omit<React.ComponentProps<typeof Card>, 'children'> & {
+    /** Optional children for the body */
+    children?: React.ReactNode;
+
     /** Background color of header */
     headerColor?: string;
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,5 +8,5 @@ We currently have the following components available for React Native applicatio
 -   [Header](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Header.md)
 -   [Hero & Hero Banner](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Hero.md)
 -   [Info List Item](https://github.com/pxblue/react-native-component-library/blob/dev/docs/InfoListItem.md)
--   [Score Card](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Scorecard.md)
+-   [Score Card](https://github.com/pxblue/react-native-component-library/blob/dev/docs/ScoreCard.md)
 -   [Typography](https://github.com/pxblue/react-native-component-library/blob/dev/docs/Typography.md)

--- a/docs/ScoreCard.md
+++ b/docs/ScoreCard.md
@@ -61,6 +61,8 @@ const MoreIcon = wrapIcon({ IconClass: MatIcon, name: 'more-vert' });
 
 </div>
 
+Any other props will be provided to the root element ([**Card**](https://callstack.github.io/react-native-paper/card.html)).
+
 ### Styles
 
 You can override the internal styles used by PX Blue by passing a `styles` prop. It supports the following keys:


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes an issue where you cannot put testID prop on the ScoreCard (reported by Ubiwhere).

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Extend the Card props from react native paper

