### PR TITLE
Update UserMenu dark theme icon color

### DIFF
--- a/components/src/core/user-menu/user-menu.tsx
+++ b/components/src/core/user-menu/user-menu.tsx
@@ -51,7 +51,7 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
         avatar,
         backgroundColor,
         fontColor,
-        iconColor = theme.dark ? Colors.gray[200] : Colors.gray[500], // @TODO: PXBLUE-2122 - remove this hardcoded color value when doing theme updates (add gray[200] to dark palette, gray[500] to light palette)
+        iconColor = theme.dark ? Colors.black[200] : Colors.gray[500], // @TODO: PXBLUE-2122 - remove this hardcoded color value when doing theme updates (add black[200] to dark palette, gray[500] to light palette)
         menuTitle,
         menuSubtitle,
         menuItems,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #154.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Use black[200] instead of gray[200] for UserMenu default iconColor
