### PR TITLE
Add Collapsible Header Layout to docs storybook

### DIFF
--- a/demos/api/stories/api.stories.tsx
+++ b/demos/api/stories/api.stories.tsx
@@ -40,6 +40,7 @@ const getReadMe = (name: string): { default: string } => {
 const docFn = (): JSX.Element => <>{autoNavToDocs()}</>;
 
 stories.add('Channel Value', docFn, { notes: { markdown: getReadMe('ChannelValue.md') } });
+stories.add('Collapsible Header Layout', docFn, { notes: { markdown: getReadMe('CollapsibleHeaderLayout.md') } });
 stories.add('Empty State', docFn, { notes: { markdown: getReadMe('EmptyState.md') } });
 stories.add('Drawer', docFn, { notes: { markdown: getReadMe('Drawer.md') } });
 stories.add('Header', docFn, { notes: { markdown: getReadMe('Header.md') } });
@@ -47,8 +48,8 @@ stories.add('Hero', docFn, { notes: { markdown: getReadMe('Hero.md') } });
 stories.add('Icon Wrapper', docFn, { notes: { markdown: getReadMe('IconWrapper.md') } });
 stories.add('Info List Item', docFn, { notes: { markdown: getReadMe('InfoListItem.md') } });
 stories.add('List Item Tag', docFn, { notes: { markdown: getReadMe('ListItemTag.md') } });
-stories.add('MobileStepper', docFn, { notes: { markdown: getReadMe('MobileStepper.md') } });
+stories.add('Mobile Stepper', docFn, { notes: { markdown: getReadMe('MobileStepper.md') } });
 stories.add('Score Card', docFn, { notes: { markdown: getReadMe('ScoreCard.md') } });
 stories.add('Spacer', docFn, { notes: { markdown: getReadMe('Spacer.md') } });
 stories.add('Typography', docFn, { notes: { markdown: getReadMe('Typography.md') } });
-stories.add('UserMenu', docFn, { notes: { markdown: getReadMe('UserMenu.md') } });
+stories.add('User Menu', docFn, { notes: { markdown: getReadMe('UserMenu.md') } });


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add the Collapsible Header Layout docs to the documentation storybook
- Rename the UserMenu and MobileStepper stories for consistency
    - Forthcoming doc-it PR will fix the incoming links

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![image](https://user-images.githubusercontent.com/29152776/122923450-bbf2a900-d332-11eb-883b-22c897d3511a.png)

### No new publishing to NPM is required here...we just need to redeploy the documentation storybook.
