### PR TITLE
Add Deprecation warnings for props

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
     build_library:
         docker:
-            - image: circleci/node:12.9.1-browsers
+            - image: circleci/node:14.17-browsers
         steps:
             - checkout
             - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## 5.2.0 (July 29, 2021)
+## v5.3.0 (Unpublished)
+
+### Added
+
+-   Deprecation warnings for component properties that will be changing in version 6.0.0.
+
+## v5.2.0 (July 29, 2021)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Deprecation warnings for component properties that will be changing in version 6.0.0.
 
+### Fixed
+
+-   Minor sizing issue in the `<Header>` when rotating device from landscape to portrait orientation.
+
 ## v5.2.0 (July 29, 2021)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -70,7 +70,11 @@ to bring up a API documentation website (no interactive components).
 
 See the [documentation](https://github.com/pxblue/react-native-component-library/tree/dev/docs) for information on using these components.
 
-TODO: Add a section for upgrading from 5 -> 6
+### Upgrading from version 5 -> 6
+
+Version 6 of this library is a major update with several breaking changes. Most notably, the `IconClass` prop found in most components has been replaced by `icon` and supports more icon formats along with several other prop changes related to icon usage.
+
+Version 5.3.0 has been updated to include warning messages if you are using any deprecated props. We recommend upgrading to 5.3.0 and addressing these warnings before upgrading to version 6.
 
 ## NOTES
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ to bring up a API documentation website (no interactive components).
 
 See the [documentation](https://github.com/pxblue/react-native-component-library/tree/dev/docs) for information on using these components.
 
+TODO: Add a section for upgrading from 5 -> 6
+
 ## NOTES
 
 This component library relies on [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) - this library must be installed in your project in order to use the PX Blue components.

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-native-components",
-    "version": "5.2.0",
+    "version": "5.3.0",
     "author": "pxblue <pxblue@eaton.com>",
     "description": "Reusable React Native components for PX Blue applications",
     "repository": {

--- a/components/src/core/channel-value/channel-value.tsx
+++ b/components/src/core/channel-value/channel-value.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useCallback } from 'react';
+import React, { ComponentType, useCallback, useEffect } from 'react';
 import { View, StyleSheet, ViewProps, ViewStyle, StyleProp, TextStyle, I18nManager } from 'react-native';
 import { useTheme } from 'react-native-paper';
 import { Body1, Subtitle1 } from '../typography';
@@ -20,8 +20,26 @@ export type ChannelValueProps = ViewProps & {
     /** A component to render for the icon */
     IconClass?: ComponentType<WrapIconProps>;
 
-    /** Props to spread to the icon component */
+    /**
+     * Props to spread to the icon component
+     *
+     * @deprecated in version 6.0.0
+     */
     IconProps?: { size?: number; color?: string };
+
+    /**
+     * The size of the icon
+     *
+     * Default: fontSize
+     */
+    iconSize?: number;
+
+    /**
+     * The color of the primary icon
+     *
+     * Default: Theme.colors.text
+     */
+    iconColor?: string;
 
     /** Text to display for the units (light text) */
     units?: string;
@@ -71,10 +89,34 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
         styles = {},
         style,
         IconProps = {},
+        iconColor: iconColorProp,
+        iconSize: iconSizeProp,
         theme: themeOverride,
         ...viewProps
     } = props;
     const theme = useTheme(themeOverride);
+
+    // Compatibility to facilitate updates
+    const iconColor = iconColorProp || IconProps?.color;
+    const iconSize = iconSizeProp || IconProps?.size;
+    // Deprecation Warning
+    useEffect(() => {
+        // TODO Update docs
+        if (IconClass) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'IconClass' in ChannelValue component has been deprecated and will be removed in version 6.0.0. You should update to use the renamed 'icon' prop instead.`
+            );
+        }
+    }, [IconClass]);
+    useEffect(() => {
+        if (IconProps) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'IconProps' in ChannelValue component has been deprecated and will be removed in version 6.0.0. You should update to use the new 'iconColor' and 'iconSize' props instead.`
+            );
+        }
+    }, [IconProps]);
 
     const getColor = useCallback((): string => {
         if (!color) return theme.colors.text;
@@ -87,11 +129,11 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
         if (IconClass) {
             return (
                 <View style={[{ marginRight: Math.round(fontSize / 6) }]}>
-                    <IconClass size={fontSize} color={getColor()} {...IconProps} />
+                    <IconClass size={iconSize || fontSize} color={iconColor || getColor()} />
                 </View>
             );
         }
-    }, [IconClass, fontSize, getColor, IconProps]);
+    }, [IconClass, fontSize, getColor, iconColor, iconSize]);
 
     const getUnits = useCallback((): JSX.Element | undefined => {
         if (units) {

--- a/components/src/core/channel-value/channel-value.tsx
+++ b/components/src/core/channel-value/channel-value.tsx
@@ -101,7 +101,6 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
     const iconSize = iconSizeProp || IconProps?.size;
     // Deprecation Warning
     useEffect(() => {
-        // TODO Update docs
         if (IconClass) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/components/src/core/drawer/drawer-header.tsx
+++ b/components/src/core/drawer/drawer-header.tsx
@@ -177,7 +177,6 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
     const onIconPress = isOldFormat ? (iconProp as HeaderIconType).onPress : onIconPressProp;
     // Deprecation Warning
     useEffect(() => {
-        // TODO Update docs
         if (isOldFormat) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/components/src/core/drawer/drawer-nav-item.tsx
+++ b/components/src/core/drawer/drawer-nav-item.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState, ComponentType } from 'react';
 import { StyleSheet, View, StyleProp, ViewStyle, ViewProps, I18nManager, PixelRatio } from 'react-native';
 import { InfoListItem, InfoListItemProps as PXBInfoListItemProps } from '../info-list-item';
 import { useTheme } from 'react-native-paper';
@@ -12,6 +12,7 @@ import { findChildByType, inheritSharedProps } from './utilities';
 import * as Colors from '@pxblue/colors';
 import Collapsible from 'react-native-collapsible';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
+import { WrapIconProps } from '../icon-wrapper';
 
 export type DrawerNavItemStyles = {
     root?: StyleProp<ViewStyle>;
@@ -42,9 +43,8 @@ export type DrawerNavItemProps = AllSharedProps &
          */
         hidden?: boolean;
 
-        // TODO: Deprecate this any type and use the same thing we've been using for IconClass everywhere else.
         /** A component to render for the left icon */
-        icon?: any;
+        icon?: ComponentType<WrapIconProps>;
 
         /**
          * Is the item a parent / ancestor of the current activeItem.
@@ -320,7 +320,7 @@ export const DrawerNavItem: React.FC<DrawerNavItemProps> = (props) => {
                             divider={showDivider ? 'full' : undefined}
                             statusColor={statusColor}
                             fontColor={active ? activeItemFontColor : itemFontColor}
-                            IconClass={icon}
+                            icon={icon}
                             iconColor={active ? activeItemIconColor : itemIconColor}
                             rightComponent={
                                 (actionComponent || rightComponent) && (

--- a/components/src/core/empty-state/empty-state.tsx
+++ b/components/src/core/empty-state/empty-state.tsx
@@ -108,7 +108,6 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
     const Icon = iconProp || IconClass;
     // Deprecation Warning
     useEffect(() => {
-        // TODO Update docs
         if (IconClass) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/components/src/core/empty-state/empty-state.tsx
+++ b/components/src/core/empty-state/empty-state.tsx
@@ -40,10 +40,10 @@ export type EmptyStateProps = ViewProps & {
     /** The secondary text to display (second line) */
     description?: string;
 
-    /** A component to render for the primary icon 
-     * 
+    /** A component to render for the primary icon
+     *
      * @deprecated in version 6.0.0
-    */
+     */
     IconClass?: ComponentType<WrapIconProps>;
 
     /** A component to render for the primary icon */

--- a/components/src/core/empty-state/empty-state.tsx
+++ b/components/src/core/empty-state/empty-state.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useCallback } from 'react';
+import React, { ComponentType, useCallback, useEffect } from 'react';
 import { View, StyleSheet, StyleProp, ViewStyle, TextStyle, ViewProps, PixelRatio } from 'react-native';
 import { useTheme } from 'react-native-paper';
 import { H6, Subtitle2 } from '../typography';
@@ -43,8 +43,14 @@ export type EmptyStateProps = ViewProps & {
     /* A component to render for the primary icon */
     IconClass?: ComponentType<WrapIconProps>;
 
-    // TODO: Deprecate this since it is redundant with the other props
-    /** Props to spread to the primary icon component */
+    /* A component to render for the primary icon */
+    icon?: ComponentType<WrapIconProps>;
+
+    /**
+     * Props to spread to the primary icon component
+     *
+     * @deprecated in version 6.0.0
+     */
     IconProps?: { size?: number; color?: string };
 
     /** The size of the primary icon (100-200) */
@@ -83,6 +89,7 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
         description,
         actions,
         IconClass,
+        icon: iconProp,
         iconColor,
         iconSize,
         IconProps = {},
@@ -93,6 +100,27 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
     } = props;
     const theme = useTheme(themeOverride);
     const defaultStyles = makeStyles(theme, PixelRatio.getFontScale());
+
+    // Compatibility to facilitate updates
+    const Icon = iconProp || IconClass;
+    // Deprecation Warning
+    useEffect(() => {
+        // TODO Update docs
+        if (IconClass) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'IconClass' in EmptyState component has been deprecated and will be removed in version 6.0.0. You should update to use the renamed 'icon' prop instead.`
+            );
+        }
+    }, [IconClass]);
+    useEffect(() => {
+        if (IconProps) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'IconProps' in EmptyState component has been deprecated and will be removed in version 6.0.0. You should update to use the 'iconColor' and 'iconSize' props instead.`
+            );
+        }
+    }, [IconProps]);
 
     const normalizeIconSize = useCallback((): number => {
         if (!iconSize) return 100;
@@ -110,10 +138,10 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {
-        if (IconClass) {
-            return <IconClass size={normalizeIconSize()} color={getColor(iconColor)} {...IconProps} />;
+        if (Icon) {
+            return <Icon size={normalizeIconSize()} color={getColor(iconColor)} {...IconProps} />;
         }
-    }, [IconClass, IconProps, normalizeIconSize, getColor, iconColor]);
+    }, [Icon, IconProps, normalizeIconSize, getColor, iconColor]);
 
     return (
         <View style={[defaultStyles.root, styles.root, style]} {...viewProps}>

--- a/components/src/core/empty-state/empty-state.tsx
+++ b/components/src/core/empty-state/empty-state.tsx
@@ -34,16 +34,19 @@ const makeStyles = (theme: ReactNativePaper.Theme, fontScale: number): StyleShee
     });
 
 export type EmptyStateProps = ViewProps & {
-    /* The primary text to display (first line) */
+    /** The primary text to display (first line) */
     title: string;
 
-    /* The secondary text to display (second line) */
+    /** The secondary text to display (second line) */
     description?: string;
 
-    /* A component to render for the primary icon */
+    /** A component to render for the primary icon 
+     * 
+     * @deprecated in version 6.0.0
+    */
     IconClass?: ComponentType<WrapIconProps>;
 
-    /* A component to render for the primary icon */
+    /** A component to render for the primary icon */
     icon?: ComponentType<WrapIconProps>;
 
     /**
@@ -59,7 +62,7 @@ export type EmptyStateProps = ViewProps & {
     /** The color of the primary icon */
     iconColor?: string;
 
-    /* Additional components to render below the text (e.g., action buttons) */
+    /** Additional components to render below the text (e.g., action buttons) */
     actions?: JSX.Element;
 
     /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */

--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -31,6 +31,7 @@ import { $DeepPartial } from '@callstack/react-theme-provider';
 import createAnimatedComponent = Animated.createAnimatedComponent;
 import { usePrevious } from '../hooks/usePrevious';
 import { useHeaderDimensions } from '../hooks/useHeaderDimensions';
+import { WrapIconProps } from '../icon-wrapper';
 const AnimatedSafeAreaView = createAnimatedComponent(SafeAreaView);
 
 const headerStyles = (
@@ -154,8 +155,18 @@ export type HeaderProps = ViewProps & {
     /** Optional header third line of text (hidden when collapsed) */
     info?: ReactNode;
 
-    /** Icon to show to the left of the title, primarily used to trigger the menu / drawer */
+    /**
+     * Icon to show to the left of the title, primarily used to trigger the menu / drawer
+     *
+     * @deprecated in version 6.0.0
+     */
     navigation?: HeaderIcon;
+
+    /** Icon to show to the left of the title, primarily used to trigger the menu / drawer */
+    icon?: ComponentType<WrapIconProps>;
+
+    /** Callback to execute when the icon is pressed */
+    onIconPress?: () => void;
 
     /**
      * Y-value of the scroll position of the linked ScrollView (dynamic variant only)
@@ -239,6 +250,8 @@ export const Header: React.FC<HeaderProps> = (props) => {
         fontColor,
         info,
         navigation,
+        icon: iconProp,
+        onIconPress: onIconPressProp,
         scrollPosition = new Animated.Value(0),
         searchableConfig,
         startExpanded,
@@ -252,6 +265,20 @@ export const Header: React.FC<HeaderProps> = (props) => {
         updateScrollView = (): void => {},
         ...viewProps
     } = props;
+
+    // Compatibility to facilitate updates
+    const Icon = iconProp || navigation?.icon;
+    const onIconPress = onIconPressProp || navigation?.onPress;
+    // Deprecation Warning
+    useEffect(() => {
+        // TODO Update docs
+        if (navigation) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'navigation' in Header component has been deprecated and will be removed in version 6.0.0. You should update to use the new 'icon' and 'onIconPress' props instead.`
+            );
+        }
+    }, [navigation]);
 
     const { getScaledHeight, LANDSCAPE } = useHeaderDimensions();
 
@@ -700,7 +727,11 @@ export const Header: React.FC<HeaderProps> = (props) => {
                                     style={styles.backgroundImage}
                                 />
                                 <Animated.View style={[contentStyle(), styles.content]}>
-                                    <HeaderNavigationIcon navigation={navigation} style={styles.navigationIcon} />
+                                    <HeaderNavigationIcon
+                                        icon={Icon}
+                                        onPress={onIconPress}
+                                        style={styles.navigationIcon}
+                                    />
                                     <HeaderContent
                                         theme={theme}
                                         title={title}

--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -272,7 +272,6 @@ export const Header: React.FC<HeaderProps> = (props) => {
     const onIconPress = onIconPressProp || navigation?.onPress;
     // Deprecation Warning
     useEffect(() => {
-        // TODO Update docs
         if (navigation) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -189,6 +189,7 @@ export type HeaderProps = ViewProps & {
         backgroundImage?: StyleProp<ImageStyle>;
         content?: StyleProp<ViewStyle>;
         navigationIcon?: StyleProp<ViewStyle>;
+        icon?: StyleProp<ViewStyle>;
         textContent?: StyleProp<ViewStyle>;
         title?: StyleProp<TextStyle>;
         subtitle?: StyleProp<TextStyle>;
@@ -730,7 +731,7 @@ export const Header: React.FC<HeaderProps> = (props) => {
                                     <HeaderNavigationIcon
                                         icon={Icon}
                                         onPress={onIconPress}
-                                        style={styles.navigationIcon}
+                                        style={[styles.navigationIcon, styles.icon]}
                                     />
                                     <HeaderContent
                                         theme={theme}

--- a/components/src/core/header/headerActionItems.tsx
+++ b/components/src/core/header/headerActionItems.tsx
@@ -108,7 +108,7 @@ export const HeaderActionItems: React.FC<ActionItemProps> = (props) => {
                             onPress={actionItem.onPress}
                             style={[defaultStyles.actionItem, styles.actionItem]}
                         >
-                            <HeaderIcon IconClass={actionItem.icon} />
+                            <HeaderIcon icon={actionItem.icon} />
                         </TouchableOpacity>
                     );
                 })}

--- a/components/src/core/header/headerIcon.tsx
+++ b/components/src/core/header/headerIcon.tsx
@@ -5,7 +5,7 @@ import { useColor } from './contexts/ColorContextProvider';
 
 type HeaderIconProps = {
     /** A component to render for the icon  */
-    IconClass?: ComponentType<WrapIconProps>;
+    icon?: ComponentType<WrapIconProps>;
 };
 /**
  * HeaderIcon component
@@ -13,10 +13,10 @@ type HeaderIconProps = {
  * The HeaderIcon is a helper component that is used to properly size and space icons in the Header component.
  */
 export const HeaderIcon: React.FC<HeaderIconProps> = (props) => {
-    const { IconClass } = props;
+    const { icon: Icon } = props;
     const { color } = useColor();
-    if (IconClass) {
-        return <IconClass size={ICON_SIZE} color={color} allowFontScaling />;
+    if (Icon) {
+        return <Icon size={ICON_SIZE} color={color} allowFontScaling />;
     }
     return null;
 };

--- a/components/src/core/header/headerNavigationIcon.tsx
+++ b/components/src/core/header/headerNavigationIcon.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { ComponentType } from 'react';
 import { TouchableOpacity, StyleSheet, StyleProp, ViewStyle, I18nManager, PixelRatio } from 'react-native';
 import { ICON_SIZE } from './constants';
-import { HeaderIcon as HeaderIconType } from '../__types__';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import { HeaderIcon } from './headerIcon';
 import { useSearch } from './contexts/SearchContextProvider';
 import { useColor } from './contexts/ColorContextProvider';
+import { WrapIconProps } from '../icon-wrapper';
 
 const makeStyles = (): StyleSheet.NamedStyles<{
     navigation: ViewStyle;
@@ -27,7 +27,10 @@ const makeStyles = (): StyleSheet.NamedStyles<{
 };
 type HeaderNavigationProps = {
     /** A component to render for the navigation icon */
-    navigation?: HeaderIconType;
+    icon?: ComponentType<WrapIconProps>;
+
+    /** Callback function to call when the icon is pressed */
+    onPress?: () => void;
 
     /** Style to apply to the Touchable element */
     style?: StyleProp<ViewStyle>;
@@ -38,7 +41,7 @@ type HeaderNavigationProps = {
  * The HeaderNavigationIcon is a helper component that is used to properly size and space the main navigation icon (on the left) in the Header component.
  */
 export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => {
-    const { navigation, style } = props;
+    const { icon, onPress, style } = props;
     const { searching, onClose } = useSearch();
     const { color } = useColor();
     const defaultStyles = makeStyles();
@@ -60,15 +63,15 @@ export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => 
             </TouchableOpacity>
         );
     }
-    if (navigation) {
+    if (icon) {
         return (
             <TouchableOpacity
                 testID={'header-navigation'}
-                onPress={navigation.onPress}
+                onPress={onPress}
                 style={[defaultStyles.navigation, style]}
-                disabled={!navigation.onPress}
+                disabled={!onPress}
             >
-                <HeaderIcon IconClass={navigation.icon} />
+                <HeaderIcon icon={icon} />
             </TouchableOpacity>
         );
     }

--- a/components/src/core/hero/hero.tsx
+++ b/components/src/core/hero/hero.tsx
@@ -164,7 +164,6 @@ export const Hero: React.FC<HeroProps> = (props) => {
     const valueIcon = valueIconProp || ValueIconClass;
     // Deprecation Warning
     useEffect(() => {
-        // TODO Update docs
         if (IconClass) {
             // eslint-disable-next-line no-console
             console.warn(
@@ -173,7 +172,6 @@ export const Hero: React.FC<HeroProps> = (props) => {
         }
     }, [IconClass]);
     useEffect(() => {
-        // TODO Update docs
         if (ValueIconClass) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/components/src/core/hero/hero.tsx
+++ b/components/src/core/hero/hero.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useCallback } from 'react';
+import React, { ComponentType, useCallback, useEffect } from 'react';
 import {
     StyleSheet,
     TouchableOpacity,
@@ -57,8 +57,15 @@ export type HeroProps = ViewProps & {
     /** The text shown below the ChannelValue */
     label: string;
 
-    /** A component to render for the primary icon  */
+    /**
+     * A component to render for the primary icon
+     *
+     * @deprecated in version 6.0.0
+     */
     IconClass: ComponentType<WrapIconProps>;
+
+    /** A component to render for the primary icon  */
+    icon?: ComponentType<WrapIconProps>;
 
     /**
      * The size of the primary icon (10-48)
@@ -91,8 +98,14 @@ export type HeroProps = ViewProps & {
     /** Value for the ChannelValue child */
     value?: number | string;
 
-    /** A component to render for the ChannelValue child */
+    /**
+     * A component to render for the ChannelValue child icon
+     *
+     * @deprecated in version 6.0.0
+     */
     ValueIconClass?: ComponentType<WrapIconProps>;
+    /** A component to render for the ChannelValue child icon */
+    valueIcon?: ComponentType<WrapIconProps>;
 
     /** Color to use for the ChannelValue text */
     valueColor?: string;
@@ -129,11 +142,13 @@ export const Hero: React.FC<HeroProps> = (props) => {
         label,
         value,
         ValueIconClass,
+        valueIcon: valueIconProp,
         valueColor,
         fontSize = 20,
         units,
         onPress,
         IconClass,
+        icon: iconProp,
         iconColor,
         iconSize,
         iconBackgroundColor,
@@ -143,6 +158,29 @@ export const Hero: React.FC<HeroProps> = (props) => {
         theme: themeOverride,
         ...viewProps
     } = props;
+
+    // Compatibility to facilitate updates
+    const Icon = iconProp || IconClass;
+    const valueIcon = valueIconProp || ValueIconClass;
+    // Deprecation Warning
+    useEffect(() => {
+        // TODO Update docs
+        if (IconClass) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'IconClass' in Hero component has been deprecated and will be removed in version 6.0.0. You should update to use the renamed 'icon' prop instead.`
+            );
+        }
+    }, [IconClass]);
+    useEffect(() => {
+        // TODO Update docs
+        if (ValueIconClass) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'ValueIconClass' in Hero component has been deprecated and will be removed in version 6.0.0. You should update to use the renamed 'valueIcon' prop instead.`
+            );
+        }
+    }, [ValueIconClass]);
 
     const theme = useTheme(themeOverride);
     const fontScale = PixelRatio.getFontScale();
@@ -164,10 +202,10 @@ export const Hero: React.FC<HeroProps> = (props) => {
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {
-        if (IconClass) {
-            return <IconClass size={normalizeIconSize()} color={getColor(iconColor)} />;
+        if (Icon) {
+            return <Icon size={normalizeIconSize()} color={getColor(iconColor)} />;
         }
-    }, [IconClass, normalizeIconSize, getColor, iconColor]);
+    }, [Icon, normalizeIconSize, getColor, iconColor]);
 
     return (
         <TouchableOpacity
@@ -190,7 +228,7 @@ export const Hero: React.FC<HeroProps> = (props) => {
                     <ChannelValue
                         value={value}
                         units={units}
-                        IconClass={ValueIconClass}
+                        IconClass={valueIcon}
                         color={valueColor}
                         fontSize={fontSize}
                     />

--- a/components/src/core/hero/hero.tsx
+++ b/components/src/core/hero/hero.tsx
@@ -62,7 +62,7 @@ export type HeroProps = ViewProps & {
      *
      * @deprecated in version 6.0.0
      */
-    IconClass: ComponentType<WrapIconProps>;
+    IconClass?: ComponentType<WrapIconProps>;
 
     /** A component to render for the primary icon  */
     icon?: ComponentType<WrapIconProps>;

--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, useCallback } from 'react';
+import React, { ComponentType, useCallback, useEffect } from 'react';
 import {
     StyleSheet,
     View,
@@ -10,7 +10,7 @@ import {
     I18nManager,
     PixelRatio,
 } from 'react-native';
-import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import MatIcon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useTheme, Divider as PaperDivider } from 'react-native-paper';
 import { Subtitle1 } from '../typography';
 import * as Colors from '@pxblue/colors';
@@ -206,8 +206,15 @@ export type InfoListItemProps = ViewProps & {
      */
     iconAlign?: IconAlign;
 
-    /** A component to render for the icon */
+    /**
+     * A component to render for the icon
+     *
+     * @deprecated in version 6.0.0
+     */
     IconClass?: ComponentType<WrapIconProps>;
+
+    /** A component to render for the icon */
+    icon?: ComponentType<WrapIconProps>;
 
     /** Color to use for the icon */
     iconColor?: string;
@@ -294,6 +301,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         backgroundColor, //eslint-disable-line @typescript-eslint/no-unused-vars
         onPress,
         IconClass,
+        icon: iconProp,
         hidePadding,
         styles = {},
         theme: themeOverride,
@@ -303,6 +311,19 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     const theme = useTheme(themeOverride);
     const fontScale = PixelRatio.getFontScale();
     const defaultStyles = infoListItemStyles(props, theme, fontScale);
+
+    // Compatibility to facilitate updates
+    const Icon = iconProp || IconClass;
+    // Deprecation Warning
+    useEffect(() => {
+        // TODO Update docs
+        if (IconClass) {
+            // eslint-disable-next-line no-console
+            console.warn(
+                `Property 'IconClass' in InfoListItem component has been deprecated and will be removed in version 6.0.0. You should update to use the renamed 'icon' prop instead.`
+            );
+        }
+    }, [IconClass]);
 
     const getIconColor = useCallback((): string => {
         if (iconColor) return iconColor;
@@ -317,14 +338,14 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     }, [iconColor, avatar, statusColor, theme]);
 
     const getIcon = useCallback((): JSX.Element | undefined => {
-        if (IconClass) {
+        if (Icon) {
             return (
                 <View style={avatar ? [defaultStyles.avatar, styles.avatar] : [defaultStyles.icon, styles.icon]}>
-                    <IconClass size={24} color={getIconColor()} />
+                    <Icon size={24} color={getIconColor()} />
                 </View>
             );
         }
-    }, [IconClass, avatar, getIconColor, defaultStyles, styles]);
+    }, [Icon, avatar, getIconColor, defaultStyles, styles]);
 
     const getSubtitle = useCallback((): JSX.Element[] | null => {
         if (!subtitle) {
@@ -355,7 +376,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
             return rightComponent;
         } else if (chevron) {
             return (
-                <Icon
+                <MatIcon
                     name="chevron-right"
                     size={24}
                     color={theme.colors.text}

--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -316,7 +316,6 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     const Icon = iconProp || IconClass;
     // Deprecation Warning
     useEffect(() => {
-        // TODO Update docs
         if (IconClass) {
             // eslint-disable-next-line no-console
             console.warn(

--- a/components/src/core/utility/spacer.tsx
+++ b/components/src/core/utility/spacer.tsx
@@ -11,7 +11,7 @@ const spacerStyles = (props: SpacerProps): StyleSheet.NamedStyles<{ root: ViewSt
     });
 
 export type SpacerProps = ViewProps & {
-    /* Flex grow/shrink value for use in flex layouts */
+    /** Flex grow/shrink value for use in flex layouts */
     flex?: number;
 
     /** Height (in dp) for static layouts */

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -24,16 +24,19 @@ const Battery = wrapIcon({ IconClass: _Battery });
 
 <div style="overflow: auto">
 
-| Prop Name | Description                           | Type                                               | Required | Default             |
-| --------- | ------------------------------------- | -------------------------------------------------- | -------- | ------------------- |
-| value     | Text to display for the value         | `string` \| `number`                               | yes      |                     |
-| IconClass | A component to render for the icon    | `React.Component<{ size: number, color: string }>` | no       |                     |
-| IconProps | Props to pass through to the icon     | `{ size?: number, color?: string }`                | no       |                     |
-| units     | Text to display for the units         | `string`                                           | no       |                     |
-| prefix    | If true, shows units before the value | `boolean`                                          | no       | `false`             |
-| fontSize  | The size used for the text elements   | `number`                                           | no       | 'medium'            |
-| color     | The color used for the text elements  | `string`                                           | no       | `theme.colors.text` |
-| theme     | Theme value overrides                 | `$DeepPartial<ReactNativePaper.Theme>`             | no       |                     |
+| Prop Name     | Description                           | Type                                               | Required | Default             |
+| ------------- | ------------------------------------- | -------------------------------------------------- | -------- | ------------------- |
+| value         | Text to display for the value         | `string` \| `number`                               | yes      |                     |
+| ~~IconClass~~ | A component to render for the icon    | `React.Component<{ size: number, color: string }>` | no       |                     |
+| IconProps     | Props to pass through to the icon     | `{ size?: number, color?: string }`                | no       |                     |
+| icon          | A component to render for the icon    | `React.Component<{ size: number, color: string }>` | no       |                     |
+| iconSize      | The size to render the icon           | `number`                                           | no       | `fontSize`          |
+| iconColor     | A component to render for the icon    | `string`                                           | no       | `theme.colors.text` |
+| units         | Text to display for the units         | `string`                                           | no       |                     |
+| prefix        | If true, shows units before the value | `boolean`                                          | no       | `false`             |
+| fontSize      | The size used for the text elements   | `number`                                           | no       | 'medium'            |
+| color         | The color used for the text elements  | `string`                                           | no       | `theme.colors.text` |
+| theme         | Theme value overrides                 | `$DeepPartial<ReactNativePaper.Theme>`             | no       |                     |
 
 </div>
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -68,17 +68,18 @@ The `<DrawerHeader>` is a subsection that appears at the top of `<Drawer>`. Its 
 
 <div style="overflow: auto">
 
-| Prop Name         | Description                           | Type                                   | Required | Default                |
-| ----------------- | ------------------------------------- | -------------------------------------- | -------- | ---------------------- |
-| backgroundColor   | The color used for the background     | `string`                               | no       | `theme.colors.primary` |
-| backgroundImage   | An image to display in the header     | `ImageSourcePropType`                  | no       |                        |
-| backgroundOpacity | The opacity of the background image   | `number`                               | no       | `0.3`                  |
-| fontColor         | The color of the text elements        | `string`                               | no       | `theme.colors.surface` |
-| icon              | Icon to show to the left of the title | `HeaderIcon` (see Header)              | no       |                        |
-| subtitle          | The second line of text               | `string`                               | no       |                        |
-| title             | The first line of text                | `string`                               | no       |                        |
-| titleContent      | Custom content for header title area  | `ReactNode`                            | no       |                        |
-| theme             | Theme value overrides                 | `$DeepPartial<ReactNativePaper.Theme>` | no       |                        |
+| Prop Name         | Description                                    | Type                                                                            | Required | Default                |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------------- | -------- | ---------------------- |
+| backgroundColor   | The color used for the background              | `string`                                                                        | no       | `theme.colors.primary` |
+| backgroundImage   | An image to display in the header              | `ImageSourcePropType`                                                           | no       |                        |
+| backgroundOpacity | The opacity of the background image            | `number`                                                                        | no       | `0.3`                  |
+| fontColor         | The color of the text elements                 | `string`                                                                        | no       | `theme.colors.surface` |
+| icon              | Icon to show to the left of the title          | `HeaderIcon` (see Header) \| `React.Component<{ size: number, color: string }>` | no       |                        |
+| onIconPress       | A callback to execute when the icon is pressed | `() => void`                                                                    | no       |                        |
+| subtitle          | The second line of text                        | `string`                                                                        | no       |                        |
+| title             | The first line of text                         | `string`                                                                        | no       |                        |
+| titleContent      | Custom content for header title area           | `ReactNode`                                                                     | no       |                        |
+| theme             | Theme value overrides                          | `$DeepPartial<ReactNativePaper.Theme>`                                          | no       |                        |
 
 </div>
 

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -22,16 +22,17 @@ const Battery = wrapIcon({ IconClass: _Battery });
 
 <div style="overflow: auto">
 
-| Prop Name   | Description                                    | Type                                               | Required | Default |
-| ----------- | ---------------------------------------------- | -------------------------------------------------- | -------- | ------- |
-| title       | The primary text to display (first line)       | `string`                                           | yes      |         |
-| description | The secondary text to display (second line)    | `string`                                           | no       |         |
-| IconClass   | A component to render for the primary icon     | `React.Component<{ size: number, color: string }>` | no       |         |
-| IconProps   | Props to spread to the primary icon            | `{ size?: number, color?: string }`                | no       |         |
-| iconSize    | The size of the primary icon (100-200)         | `number`                                           | no       | 100     |
-| iconColor   | The color of the primary icon                  | `string`                                           | no       | `text`  |
-| actions     | Additional components to render below the text | `JSX.Element`                                      | no       |         |
-| theme       | Theme value overrides                          | `$DeepPartial<ReactNativePaper.Theme>`             | no       |         |
+| Prop Name     | Description                                    | Type                                               | Required | Default |
+| ------------- | ---------------------------------------------- | -------------------------------------------------- | -------- | ------- |
+| title         | The primary text to display (first line)       | `string`                                           | yes      |         |
+| description   | The secondary text to display (second line)    | `string`                                           | no       |         |
+| ~~IconClass~~ | A component to render for the primary icon     | `React.Component<{ size: number, color: string }>` | no       |         |
+| icon          | A component to render for the primary icon     | `React.Component<{ size: number, color: string }>` | no       |         |
+| ~~IconProps~~ | Props to spread to the primary icon            | `{ size?: number, color?: string }`                | no       |         |
+| iconSize      | The size of the primary icon (100-200)         | `number`                                           | no       | 100     |
+| iconColor     | The color of the primary icon                  | `string`                                           | no       | `text`  |
+| actions       | Additional components to render below the text | `JSX.Element`                                      | no       |         |
+| theme         | Theme value overrides                          | `$DeepPartial<ReactNativePaper.Theme>`             | no       |         |
 
 </div>
 

--- a/docs/Header.md
+++ b/docs/Header.md
@@ -37,7 +37,9 @@ const MoreIcon = wrapIcon({IconClass: Icon, name:'more-vert'});
 | expandedHeight     | The height of the header when expanded                                                                                     | `number`                                                                            | no       | 200                      |
 | fontColor          | Color of the title, subtitle, info, and icons in the header                                                                | `string`                                                                            | no       | `theme.colors.onPrimary` |
 | info               | Third line of text (hidden on collapse)                                                                                    | `ReactNode`                                                                         | no       |                          |
-| navigation         | Icon to show to the left of the title                                                                                      | `HeaderIcon`                                                                        | no       |                          |
+| icon               | Icon to show to the left of the title                                                                                      | `React.Component<{ size: number, color: string }>`                                  | no       |                          |
+| onIconPress        | A callback to execute when the icon is pressed                                                                             | `() => void`                                                                        | no       |                          |
+| ~~navigation~~     | Icon to show to the left of the title                                                                                      | `HeaderIcon`                                                                        | no       |                          |
 | scrollPosition     | Y-value of the linked ScrollView (dynamic variant only)                                                                    | `Animated.Value`                                                                    | no       |                          |
 | searchableConfig   | Configuration object for search behavior                                                                                   | `SearchableConfig`                                                                  | no       |                          |
 | startExpanded      | Renders header in the expanded state to start                                                                              | `boolean`                                                                           | no       | `false`                  |
@@ -55,20 +57,21 @@ const MoreIcon = wrapIcon({IconClass: Icon, name:'more-vert'});
 
 You can override the internal styles used by PX Blue by passing a `styles` prop. It supports the following keys:
 
-| Name            | Description                                |
-| --------------- | ------------------------------------------ |
-| root            | Styles applied to the root element         |
-| actionItem      | Styles applied to the action icon(s)       |
-| actionPanel     | Styles applied to the actions container    |
-| avatar          | Styles applied to the action components    |
-| backgroundImage | Styles applied to the background image     |
-| content         | Styles applied to the content wrapper      |
-| info            | Styles applied to the info element         |
-| navigationIcon  | Styles applied to the navigation icon      |
-| search          | Styles applied to the search input element |
-| subtitle        | Styles applied to the subtitle element     |
-| textContent     | Styles applied to the text wrapper         |
-| title           | Styles applied to the title element        |
+| Name               | Description                                |
+| ------------------ | ------------------------------------------ |
+| root               | Styles applied to the root element         |
+| actionItem         | Styles applied to the action icon(s)       |
+| actionPanel        | Styles applied to the actions container    |
+| avatar             | Styles applied to the action components    |
+| backgroundImage    | Styles applied to the background image     |
+| content            | Styles applied to the content wrapper      |
+| info               | Styles applied to the info element         |
+| icon               | Styles applied to the navigation icon      |
+| ~~navigationIcon~~ | Styles applied to the navigation icon      |
+| search             | Styles applied to the search input element |
+| subtitle           | Styles applied to the subtitle element     |
+| textContent        | Styles applied to the text wrapper         |
+| title              | Styles applied to the title element        |
 
 # HeaderIcon
 

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -34,13 +34,15 @@ const Battery = wrapIcon({ IconClass: _Battery });
 | Prop Name           | Description                                     | Type                                               | Required | Default                |
 | ------------------- | ----------------------------------------------- | -------------------------------------------------- | -------- | ---------------------- |
 | label               | The text shown below the `ChannelValue`         | `string`                                           | yes      |                        |
-| IconClass           | A component to render for the primary icon      | `React.Component<{ size: number, color: string }>` | yes      |                        |
+| ~~IconClass~~       | A component to render for the primary icon      | `React.Component<{ size: number, color: string }>` | yes      |                        |
+| icon                | A component to render for the primary icon      | `React.Component<{ size: number, color: string }>` | yes      |                        |
 | iconSize            | The size of the primary icon (10-48)            | `number`                                           | no       | 36                     |
 | iconColor           | The color of the primary icon                   | `string`                                           | no       | `theme.colors.text`    |
 | iconBackgroundColor | The color behind the primary icon               | `string`                                           | no       | `theme.colors.surface` |
 | fontSize            | The text size for the ChannelValue              | `number`                                           | no       | 20                     |
 | value               | The value for the ChannelValue                  | `string` \| `number`                               | no       |                        |
-| ValueIconClass      | A component to render for the ChannelValue icon | `React.Component<{ size: number, color: string }>` | no       |                        |
+| ~~ValueIconClass~~  | A component to render for the ChannelValue icon | `React.Component<{ size: number, color: string }>` | no       |                        |
+| valueIcon           | A component to render for the ChannelValue icon | `React.Component<{ size: number, color: string }>` | no       |                        |
 | valueColor          | Color to use for the ChannelValue text          | `string`                                           | no       | `text`                 |
 | units               | The units for the ChannelValue                  | `string`                                           | no       |                        |
 | onPress             | A function to execute when pressed              | `function`                                         | no       |                        |

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -42,7 +42,8 @@ You can also supply an array of items that will be displayed as a character-sepa
 | fontColor         | Color to use for text elements                                  | `string`                                           | no       |                |
 | hidePadding       | Hide padding reserved for icons when there is no icon           | `boolean`                                          | no       | `false`        |
 | iconAlign         | Icon alignment when `avatar` is set to`false`                   | `'left'` \| `'center'` \| `'right'`                | no       | 'left'         |
-| IconClass         | A component to render for the icon                              | `React.Component<{ size: number, color: string }>` | no       |                |
+| icon              | A component to render for the icon                              | `React.Component<{ size: number, color: string }>` | no       |                |
+| ~~IconClass~~     | A component to render for the icon                              | `React.Component<{ size: number, color: string }>` | no       |                |
 | iconColor         | Color to use for the icon                                       | `string`                                           | no       |                |
 | info              | The text to show on the third line                              | `string` \| `Array<React.ReactNode>`               | no       |                |
 | leftComponent     | Custom content to render between the icon and the text elements | `JSX.Element`                                      | no       |                |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add deprecation warnings (console.warn) for properties that will be going away or changing
- Add the new props and a conversion from old -> new to facilitate users making the changes before upgrading to v6
- 
<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run the showcase demo
- You should be presented with a bunch of YellowBox warnings
- Make some of the necessary changes (e.g., changing `IconClass` to `icon`) and you should see the warning count go down.
