### PR TITLE
UserMenu menuItem prop color application bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 6.0.0 (Unreleased)
 
+### Fixed
+
+-   Issue with `<UserMenu>` that would not apply `fontColor`, `iconColor`, and `backgroundColor` appropriately via `menuItems` prop object.
+
 ### Added
 
 -   New peerDependency on [@pxblue/react-native-vector-icons](https://www.npmjs.com/package/@pxblue/react-native-vector-icons).
@@ -17,7 +21,6 @@
 ### Removed
 
 -   `IconProps` prop from `<EmptyState>` component — use `iconSize` and `iconColor` props instead.
-
 
 ## 5.2.0 (July 28, 2021)
 

--- a/components/src/core/user-menu/user-menu.tsx
+++ b/components/src/core/user-menu/user-menu.tsx
@@ -127,9 +127,9 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
                                     closeMenu();
                                     if (menuItem.onPress) menuItem.onPress();
                                 }}
-                                iconColor={iconColor || menuItem.iconColor}
-                                fontColor={fontColor || menuItem.fontColor}
-                                backgroundColor={backgroundColor || menuItem.backgroundColor}
+                                iconColor={menuItem.iconColor || iconColor}
+                                fontColor={menuItem.fontColor || fontColor}
+                                backgroundColor={menuItem.backgroundColor || backgroundColor}
                                 dense={menuItem.dense !== undefined ? menuItem.dense : true}
                                 styles={Object.assign(menuItemStyles, {
                                     title: Object.assign(


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fixes issue with `<UserMenu>` that would not apply `fontColor`, `iconColor`, and `backgroundColor` appropriately via `menuItems` prop object.

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Update the UserMenu story `menuItems` variable to be something like:
`const menuItems: InfoListItemProps[] = [
    { title: 'Change Password', icon: VpnKeyIcon, iconColor: '#deadbeef', fontColor: 'blue', backgroundColor: 'orange' },
    { title: 'Preferences', icon: SettingsIcon, iconColor: 'red' },
    { title: 'Log Out', icon: ExitToAppIcon, iconColor: Colors.orange[300] },
];`
- Start storybook and navigate to a `UserMenu` story.
- Click the avatar and observe the application of various colors.
