### PR TITLE
Update EmptyState default icon color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 
-## v5.4.1 (September 20, 2021)
+## v5.4.1 (unreleased)
 
 ### Added
 
 -   Deprecation warnings for the `<Hero>` component properties that will be changing in version 6.0.0.
+
+### Changed
+
+-   Update `<EmptyState>` default icon color to match the DSM ([#173](https://github.com/pxblue/react-native-component-library/issues/173)).
 
 ## v5.4.0 (August 20, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
--   Update `<EmptyState>` default icon color to match the DSM ([#173](https://github.com/pxblue/react-native-component-library/issues/173)).
+-   Update `<EmptyState>` default icon color to match the design ([#173](https://github.com/pxblue/react-native-component-library/issues/173)).
 
 ## v5.4.0 (August 20, 2021)
 

--- a/components/src/core/empty-state/__snapshots__/empty-state.test.tsx.snap
+++ b/components/src/core/empty-state/__snapshots__/empty-state.test.tsx.snap
@@ -279,7 +279,7 @@ exports[`EmptyState Tests  Icon Renders 1`] = `
     style={
       Array [
         Object {
-          "color": "#000000",
+          "color": "#727e84",
           "fontSize": 100,
         },
         Object {},

--- a/components/src/core/empty-state/empty-state.tsx
+++ b/components/src/core/empty-state/empty-state.tsx
@@ -4,6 +4,7 @@ import { useTheme } from 'react-native-paper';
 import { H6, Subtitle2 } from '../typography';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import { WrapIconProps } from '../icon-wrapper';
+import * as PXBColors from '@pxblue/colors';
 
 type EmptyStateStyles = {
     root?: ViewStyle;
@@ -24,7 +25,6 @@ const makeStyles = (theme: ReactNativePaper.Theme, fontScale: number): StyleShee
             marginTop: 16 * fontScale,
         },
         description: {
-            // @ts-ignore
             color: theme.dark ? theme.colors.textSecondary : theme.colors.text,
             textAlign: 'center',
         },
@@ -131,7 +131,7 @@ export const EmptyState: React.FC<EmptyStateProps> = (props) => {
 
     const getColor = useCallback(
         (color: string | undefined): string => {
-            if (!color) return theme.colors.textSecondary || theme.colors.text;
+            if (!color) return theme.dark ? PXBColors.black[200] : PXBColors.gray[500];
             if (Object.keys(theme.colors).indexOf(color) >= 0)
                 return theme.colors[color as keyof ReactNativePaper.Theme['colors']];
             return color;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #173.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update EmptyState default icon color


note: This is already fixed in v6 using the new themes.