### PR TITLE
Add themed component color fallbacks and fix ref issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## v6.0.0 (Unpublished)
+
+### Fixed
+
+-   Issue with missing color fallback values ([#214](https://github.com/pxblue/react-native-component-library/issues/214)).
+-   Issue regarding inability to set ref on `<ThemedTextInput>` ([#213](https://github.com/pxblue/react-native-component-library/issues/213)).
+
 ## v6.0.0 (October 1, 2021)
 
 ### Fixed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pxblue/react-native-components",
-    "version": "6.0.0",
+    "version": "6.0.1-beta.0",
     "author": "pxblue <pxblue@eaton.com>",
     "description": "Reusable React Native components for PX Blue applications",
     "repository": {

--- a/components/src/themed/ThemedAvatar.tsx
+++ b/components/src/themed/ThemedAvatar.tsx
@@ -9,12 +9,12 @@ const ThemedIconAvatar: typeof Avatar.Icon = (props) => {
         theme.dark
             ? {
                   backgroundColor:
-                      theme.colors.overrides.avatar?.background ||
-                      theme.colors.primaryPalette.main ||
+                      theme.colors.overrides?.avatar?.background ||
+                      theme.colors.primaryPalette?.main ||
                       theme.colors.primary,
               }
             : {
-                  backgroundColor: theme.colors.primaryPalette.light,
+                  backgroundColor: theme.colors.primaryPalette?.light || theme.colors.primary,
               },
         styleProp
     );
@@ -23,7 +23,11 @@ const ThemedIconAvatar: typeof Avatar.Icon = (props) => {
         <Avatar.Icon
             {...other}
             style={style}
-            color={colorProp || (theme.dark ? theme.colors.textPalette.primary : theme.colors.primaryPalette.main)}
+            color={
+                colorProp ||
+                (theme.dark ? theme.colors.textPalette?.primary : theme.colors.primaryPalette?.main) ||
+                theme.colors.text
+            }
             theme={themeOverride}
         />
     );
@@ -37,12 +41,12 @@ const ThemedImageAvatar: typeof Avatar.Image = (props) => {
         theme.dark
             ? {
                   backgroundColor:
-                      theme.colors.overrides.avatar?.background ||
-                      theme.colors.primaryPalette.main ||
+                      theme.colors.overrides?.avatar?.background ||
+                      theme.colors.primaryPalette?.main ||
                       theme.colors.primary,
               }
             : {
-                  backgroundColor: theme.colors.primaryPalette.light,
+                  backgroundColor: theme.colors.primaryPalette?.light || theme.colors.primary,
               },
         styleProp
     );
@@ -58,12 +62,12 @@ const ThemedTextAvatar: typeof Avatar.Text = (props) => {
         theme.dark
             ? {
                   backgroundColor:
-                      theme.colors.overrides.avatar?.background ||
-                      theme.colors.primaryPalette.main ||
+                      theme.colors.overrides?.avatar?.background ||
+                      theme.colors.primaryPalette?.main ||
                       theme.colors.primary,
               }
             : {
-                  backgroundColor: theme.colors.primaryPalette.light,
+                  backgroundColor: theme.colors.primaryPalette?.light || theme.colors.primary,
               },
         styleProp
     );
@@ -72,7 +76,11 @@ const ThemedTextAvatar: typeof Avatar.Text = (props) => {
         <Avatar.Text
             {...other}
             style={style}
-            color={colorProp || (theme.dark ? theme.colors.textPalette.primary : theme.colors.primaryPalette.main)}
+            color={
+                colorProp ||
+                (theme.dark ? theme.colors.textPalette?.primary : theme.colors.primaryPalette?.main) ||
+                theme.colors.primary
+            }
             theme={themeOverride}
         />
     );

--- a/components/src/themed/ThemedBadge.tsx
+++ b/components/src/themed/ThemedBadge.tsx
@@ -16,8 +16,8 @@ export const ThemedBadge: React.FC<ThemedBadgeProps> = (props) => {
     const fullTheme = useTheme(themeOverride);
     const theme = useAlternateTheme(
         themeOverride,
-        { colors: { notification: fullTheme.colors.primaryPalette.main } },
-        { colors: { notification: fullTheme.colors.primaryPalette.dark } }
+        { colors: { notification: fullTheme.colors.primaryPalette?.main || fullTheme.colors.primary } },
+        { colors: { notification: fullTheme.colors.primaryPalette?.dark || fullTheme.colors.primary } }
     );
 
     return <Badge {...other} theme={theme} />;

--- a/components/src/themed/ThemedBottomNavigation.tsx
+++ b/components/src/themed/ThemedBottomNavigation.tsx
@@ -17,20 +17,21 @@ export const ThemedBottomNavigation: React.FC<ThemedBottomNavigationProps> = (pr
     const defaultTheme = useTheme(themeOverride);
     const theme = useAlternateTheme(
         themeOverride,
-        { colors: { notification: defaultTheme.colors.errorPalette.main } },
-        { colors: { notification: defaultTheme.colors.errorPalette.dark } }
+        { colors: { notification: defaultTheme.colors.errorPalette?.main || defaultTheme.colors.error } },
+        { colors: { notification: defaultTheme.colors.errorPalette?.dark || defaultTheme.colors.error } }
     );
     const fullTheme = useTheme(theme);
 
     const activeColor =
         props.activeColor ||
-        (fullTheme.dark ? fullTheme.colors.primaryPalette.main : fullTheme.colors.textPalette.onPrimary.main);
+        (fullTheme.dark ? fullTheme.colors.primaryPalette?.main : fullTheme.colors.textPalette?.onPrimary?.main) ||
+        fullTheme.colors.text;
     const inactiveColor =
         props.inactiveColor ||
-        fullTheme.colors.overrides.bottomNavigation?.inactive ||
+        fullTheme.colors.overrides?.bottomNavigation?.inactive ||
         (fullTheme.dark
-            ? fullTheme.colors.textPalette.onPrimary.main
-            : Color(fullTheme.colors.textPalette.onPrimary.main).alpha(0.5).string()) ||
+            ? fullTheme.colors.textPalette?.onPrimary?.main
+            : Color(fullTheme.colors.textPalette?.onPrimary?.main).alpha(0.5).string()) ||
         fullTheme.colors.placeholder;
 
     return (
@@ -40,7 +41,9 @@ export const ThemedBottomNavigation: React.FC<ThemedBottomNavigationProps> = (pr
                 activeColor={activeColor}
                 inactiveColor={inactiveColor}
                 barStyle={Object.assign(
-                    fullTheme.dark ? { backgroundColor: fullTheme.colors.actionPalette.background } : {},
+                    fullTheme.dark
+                        ? { backgroundColor: fullTheme.colors.actionPalette?.background || fullTheme.colors.primary }
+                        : {},
                     props.barStyle
                 )}
                 theme={theme}

--- a/components/src/themed/ThemedButton.tsx
+++ b/components/src/themed/ThemedButton.tsx
@@ -32,42 +32,42 @@ export const ThemedButton: React.FC<ThemedButtonProps> = (props) => {
     if (props.disabled) {
         if (props.mode === 'text' || props.mode === undefined) {
             backgroundColor = 'transparent';
-            textColor = theme.colors.actionPalette.disabled;
+            textColor = theme.colors.actionPalette?.disabled || theme.colors.disabled;
         } else if (props.mode === 'contained') {
             if (theme.dark) {
-                backgroundColor = theme.colors.actionPalette.disabledBackground;
-                textColor = theme.colors.textPalette.disabled;
+                backgroundColor = theme.colors.actionPalette?.disabledBackground || theme.colors.disabled;
+                textColor = theme.colors.textPalette?.disabled || theme.colors.text;
             } else {
-                backgroundColor = theme.colors.primaryPalette.light;
+                backgroundColor = theme.colors.primaryPalette?.light || theme.colors.disabled;
                 textColor =
-                    theme.colors.overrides.button?.contained?.text?.disabled ||
-                    theme.colors.textPalette.disabled ||
+                    theme.colors.overrides?.button?.contained?.text?.disabled ||
+                    theme.colors.textPalette?.disabled ||
                     theme.colors.text;
             }
         } else if (props.mode === 'outlined') {
             if (theme.dark) {
                 borderColor = theme.colors.divider;
-                textColor = theme.colors.actionPalette.disabled;
+                textColor = theme.colors.actionPalette?.disabled || theme.colors.text;
             } else {
                 borderColor = theme.colors.divider;
-                textColor = theme.colors.actionPalette.disabled;
+                textColor = theme.colors.actionPalette?.disabled || theme.colors.text;
             }
         }
     } else {
         if (props.mode === 'text' || props.mode === undefined) {
             backgroundColor = 'transparent';
-            textColor = theme.colors.primaryPalette.main;
+            textColor = theme.colors.primaryPalette?.main || theme.colors.primary;
         } else if (props.mode === 'contained') {
             if (theme.dark) {
-                backgroundColor = theme.colors.primaryPalette.dark;
-                textColor = theme.colors.textPalette.onPrimary.dark;
+                backgroundColor = theme.colors.primaryPalette?.dark || theme.colors.primary;
+                textColor = theme.colors.textPalette?.onPrimary?.dark || theme.colors.text;
             } else {
-                backgroundColor = theme.colors.primaryPalette.main;
-                textColor = theme.colors.textPalette.onPrimary.main;
+                backgroundColor = theme.colors.primaryPalette?.main || theme.colors.primary;
+                textColor = theme.colors.textPalette?.onPrimary?.main || theme.colors.text;
             }
         } else if (props.mode === 'outlined') {
-            borderColor = theme.colors.primaryPalette.main;
-            textColor = theme.colors.primaryPalette.main;
+            borderColor = theme.colors.primaryPalette?.main || theme.colors.primary;
+            textColor = theme.colors.primaryPalette?.main || theme.colors.text;
         }
     }
 

--- a/components/src/themed/ThemedCheckbox.tsx
+++ b/components/src/themed/ThemedCheckbox.tsx
@@ -16,7 +16,13 @@ export const ThemedCheckboxIOS: React.FC<ThemedCheckboxIOSProps> = (props) => {
     const { theme: themeOverride, color, ...other } = props;
     const theme = useTheme(themeOverride);
 
-    return <Checkbox.IOS {...other} color={color || theme.colors.primaryPalette.main} theme={themeOverride} />;
+    return (
+        <Checkbox.IOS
+            {...other}
+            color={color || theme.colors.primaryPalette?.main || theme.colors.primary}
+            theme={themeOverride}
+        />
+    );
 };
 /**
  * ThemedCheckboxAndroid component
@@ -34,9 +40,11 @@ export const ThemedCheckboxAndroid: React.FC<ThemedCheckboxAndroidProps> = (prop
             {...other}
             uncheckedColor={
                 uncheckedColor ||
-                (props.status === 'unchecked' ? theme.colors.textPalette.secondary : theme.colors.primaryPalette.main)
+                (props.status === 'unchecked'
+                    ? theme.colors.textPalette?.secondary || theme.colors.text
+                    : theme.colors.primaryPalette?.main || theme.colors.primary)
             }
-            color={color || theme.colors.primaryPalette.main}
+            color={color || theme.colors.primaryPalette?.main || theme.colors.primary}
             theme={themeOverride}
         />
     );

--- a/components/src/themed/ThemedChip.tsx
+++ b/components/src/themed/ThemedChip.tsx
@@ -8,18 +8,28 @@ export type ThemedChipProps = React.ComponentProps<typeof Chip>;
 const getBackgroundColor: (props: ThemedChipProps, theme: ReactNativePaper.Theme) => string = (props, theme) => {
     // Filled Style
     if (props.mode === undefined || props.mode === 'flat') {
-        if (props.disabled) return theme.colors.actionPalette.disabledBackground;
+        if (props.disabled) return theme.colors.actionPalette?.disabledBackground || theme.colors.disabled;
         else if (props.selected) {
-            return theme.colors.primaryPalette[theme.dark ? 'dark' : 'main'];
+            return (
+                (theme.dark ? theme.colors.primaryPalette?.dark : theme.colors.primaryPalette?.main) ||
+                theme.colors.primary
+            );
         }
-        return theme.dark ? theme.colors.actionPalette.active : theme.colors.actionPalette.background;
+        return (
+            (theme.dark ? theme.colors.actionPalette?.active : theme.colors.actionPalette?.background) ||
+            theme.colors.background
+        );
     }
     // Outlined Style
     else if (props.disabled) return 'transparent';
     else if (props.selected) {
         return theme.dark
-            ? Color(theme.colors.primaryPalette.dark).alpha(0.2).string()
-            : Color(theme.colors.primaryPalette.main).alpha(0.05).string();
+            ? Color(theme.colors.primaryPalette?.dark || theme.colors.primary)
+                  .alpha(0.2)
+                  .string()
+            : Color(theme.colors.primaryPalette?.main || theme.colors.primary)
+                  .alpha(0.05)
+                  .string();
     }
     return 'transparent';
 };
@@ -29,17 +39,27 @@ const getTextColor: (props: ThemedChipProps, theme: ReactNativePaper.Theme) => s
     if (props.mode === undefined || props.mode === 'flat') {
         if (props.disabled)
             return theme.dark
-                ? theme.colors.textPalette.disabled
-                : Color(theme.colors.textPalette.primary).alpha(0.3).string();
+                ? theme.colors.textPalette?.disabled || theme.colors.disabled
+                : Color(theme.colors.textPalette?.primary || theme.colors.text)
+                      .alpha(0.3)
+                      .string();
         else if (props.selected) {
-            return theme.colors.textPalette.onPrimary[theme.dark ? 'dark' : 'main'];
+            return (
+                (theme.dark ? theme.colors.textPalette?.onPrimary?.dark : theme.colors.textPalette?.onPrimary?.main) ||
+                theme.colors.text
+            );
         }
-        return theme.colors.textPalette.primary;
+        return theme.colors.textPalette?.primary || theme.colors.text;
     }
     // Outlined Style
     else if (props.disabled)
-        return theme.dark ? theme.colors.textPalette.disabled : theme.colors.actionPalette.disabled;
-    return props.selected ? theme.colors.primaryPalette.main : theme.colors.textPalette.primary;
+        return (
+            (theme.dark ? theme.colors.textPalette?.disabled : theme.colors.actionPalette?.disabled) ||
+            theme.colors.disabled
+        );
+    return props.selected
+        ? theme.colors.primaryPalette?.main || theme.colors.primary
+        : theme.colors.textPalette?.primary || theme.colors.text;
 };
 
 const getBorderColor: (props: ThemedChipProps, theme: ReactNativePaper.Theme) => string = (props, theme) => {
@@ -47,7 +67,7 @@ const getBorderColor: (props: ThemedChipProps, theme: ReactNativePaper.Theme) =>
     if (props.mode === undefined || props.mode === 'flat') return 'transparent';
     // Outlined Style
     else if (props.disabled) return theme.colors.divider;
-    else if (props.selected) return theme.colors.primaryPalette.main;
+    else if (props.selected) return theme.colors.primaryPalette?.main || theme.colors.primary;
     return theme.colors.divider;
 };
 

--- a/components/src/themed/ThemedFAB.tsx
+++ b/components/src/themed/ThemedFAB.tsx
@@ -8,8 +8,8 @@ const ThemedFABComponent: React.FC<ThemedFABProps> = (props) => {
     const fullTheme = useTheme(themeOverride);
     const theme = useAlternateTheme(
         themeOverride,
-        { colors: { accent: fullTheme.colors.primaryPalette.main } },
-        { colors: { accent: fullTheme.colors.primaryPalette.dark } }
+        { colors: { accent: fullTheme.colors.primaryPalette?.main || fullTheme.colors.primary } },
+        { colors: { accent: fullTheme.colors.primaryPalette?.dark || fullTheme.colors.primary } }
     );
 
     return <FAB {...other} theme={theme} />;
@@ -32,8 +32,8 @@ const ThemedFABGroupComponent: React.FC<ThemedFABGroupProps> = (props) => {
     const defaultTheme = useTheme(themeOverride);
     const theme = useAlternateTheme(
         themeOverride,
-        { colors: { accent: defaultTheme.colors.primaryPalette.main } },
-        { colors: { accent: defaultTheme.colors.primaryPalette.dark } }
+        { colors: { accent: defaultTheme.colors.primaryPalette?.main || defaultTheme.colors.primary } },
+        { colors: { accent: defaultTheme.colors.primaryPalette?.dark || defaultTheme.colors.primary } }
     );
 
     const fullTheme = useTheme(theme);

--- a/components/src/themed/ThemedRadioButton.tsx
+++ b/components/src/themed/ThemedRadioButton.tsx
@@ -16,7 +16,13 @@ export const ThemedRadioButtonIOS: React.FC<ThemedRadioButtonIOSProps> = (props)
     const { theme: themeOverride, color, ...other } = props;
     const theme = useTheme(themeOverride);
 
-    return <RadioButton.IOS {...other} color={color || theme.colors.primaryPalette.main} theme={themeOverride} />;
+    return (
+        <RadioButton.IOS
+            {...other}
+            color={color || theme.colors.primaryPalette?.main || theme.colors.primary}
+            theme={themeOverride}
+        />
+    );
 };
 /**
  * ThemedRadioButtonAndroid component
@@ -34,9 +40,11 @@ export const ThemedRadioButtonAndroid: React.FC<ThemedRadioButtonAndroidProps> =
             {...other}
             uncheckedColor={
                 uncheckedColor ||
-                (props.status === 'unchecked' ? theme.colors.textPalette.secondary : theme.colors.primaryPalette.main)
+                (props.status === 'unchecked'
+                    ? theme.colors.textPalette?.secondary || theme.colors.text
+                    : theme.colors.primaryPalette?.main || theme.colors.primary)
             }
-            color={color || theme.colors.primaryPalette.main}
+            color={color || theme.colors.primaryPalette?.main || theme.colors.primary}
             theme={themeOverride}
         />
     );

--- a/components/src/themed/ThemedSnackbar.tsx
+++ b/components/src/themed/ThemedSnackbar.tsx
@@ -16,8 +16,8 @@ export const ThemedSnackbar: React.FC<ThemedSnackbarProps> = (props) => {
     const currentTheme = useTheme(themeOverride);
     const theme = useAlternateTheme(
         themeOverride,
-        { colors: { accent: currentTheme.colors.overrides.snackbar?.accent || currentTheme.colors.accent } },
-        { colors: { accent: currentTheme.colors.primaryPalette.dark } }
+        { colors: { accent: currentTheme.colors.overrides?.snackbar?.accent || currentTheme.colors.accent } },
+        { colors: { accent: currentTheme.colors.primaryPalette?.dark || currentTheme.colors.primary } }
     );
 
     const fullTheme = useTheme(theme);

--- a/components/src/themed/ThemedSwitch.tsx
+++ b/components/src/themed/ThemedSwitch.tsx
@@ -16,8 +16,8 @@ const getTrackColor: (props: ThemedSwitchProps, theme: ReactNativePaper.Theme) =
     if (theme.dark) {
         return {
             true: ios
-                ? theme.colors.primaryPalette.main
-                : Color(theme.colors.primaryPalette.main)
+                ? theme.colors.primaryPalette?.main || theme.colors.primary
+                : Color(theme.colors.primaryPalette?.main || theme.colors.primary)
                       .alpha(props.disabled ? 0.25 : 0.5)
                       .string(),
             false: Color(PXBColors.black[300])
@@ -27,8 +27,8 @@ const getTrackColor: (props: ThemedSwitchProps, theme: ReactNativePaper.Theme) =
     }
     return {
         true: ios
-            ? theme.colors.primaryPalette.main
-            : Color(theme.colors.primaryPalette.main)
+            ? theme.colors.primaryPalette?.main || theme.colors.primary
+            : Color(theme.colors.primaryPalette?.main || theme.colors.primary)
                   .alpha(props.disabled ? 0.19 : 0.38)
                   .string(),
         false: Color(PXBColors.black[100])
@@ -41,7 +41,7 @@ const getThumbColor: (props: ThemedSwitchProps, theme: ReactNativePaper.Theme) =
     if (Platform.OS === 'ios') return 'white';
 
     if (props.value)
-        return Color(theme.colors.primaryPalette.main)
+        return Color(theme.colors.primaryPalette?.main || theme.colors.primary)
             .mix(Color(theme.colors.surface), props.disabled ? 0.5 : 0)
             .string();
 
@@ -71,7 +71,9 @@ export const ThemedSwitch: React.FC<ThemedSwitchProps> = (props) => {
         <Switch
             ios_backgroundColor={
                 // disabled only
-                theme.dark ? theme.colors.actionPalette.disabled : Color(PXBColors.black[100]).alpha(0.38).string()
+                theme.dark
+                    ? theme.colors.actionPalette?.disabled || theme.colors.disabled
+                    : Color(PXBColors.black[100]).alpha(0.38).string()
             }
             thumbColor={getThumbColor(props, theme)}
             trackColor={getTrackColor(props, theme)}

--- a/components/src/themed/ThemedTextInput.tsx
+++ b/components/src/themed/ThemedTextInput.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { MutableRefObject } from 'react';
+import { TextInput as ReactTextInput } from 'react-native';
 import { TextInput, useTheme } from 'react-native-paper';
 import { useAlternateTheme } from './hooks/useAlternateTheme';
 
@@ -11,13 +12,27 @@ export type ThemedTextInputProps = React.ComponentProps<typeof TextInput>;
  * component. It accepts all the same props as the RNP component. The wrapper simply performs some minor theme / style overrides
  * in order to make the component look the way we want for PX Blue projects.
  */
-export const ThemedTextInput: React.FC<ThemedTextInputProps> = (props) => {
+// eslint-disable-next-line @typescript-eslint/ban-types
+const ThemedTextInputRender: React.ForwardRefRenderFunction<{}, ThemedTextInputProps> = (
+    props: ThemedTextInputProps,
+    ref: MutableRefObject<{} | null> | ((instance: {} | null) => void) | null // eslint-disable-line @typescript-eslint/ban-types
+) => {
+    // Necessary to allow use of ref (to pass focus to next TextInput on submit)
+    const inputRef = React.useRef<ReactTextInput>(null);
+    React.useImperativeHandle(ref, () => ({
+        focus: (): void => {
+            if (inputRef && inputRef.current) inputRef.current.focus();
+        },
+    }));
+
     const { theme: themeOverride, style, ...other } = props;
     const fullTheme = useTheme(themeOverride);
 
     const backgroundColorLight = props.mode === 'outlined' ? fullTheme.colors.surface : fullTheme.colors.background;
     const backgroundColorDark =
-        props.mode === 'outlined' ? fullTheme.colors.surface : fullTheme.colors.actionPalette.background;
+        props.mode === 'outlined'
+            ? fullTheme.colors.surface
+            : fullTheme.colors.actionPalette?.background || fullTheme.colors.background;
     const backgroundColor = fullTheme.dark ? backgroundColorDark : backgroundColorLight;
     const theme = useAlternateTheme(
         themeOverride,
@@ -25,12 +40,12 @@ export const ThemedTextInput: React.FC<ThemedTextInputProps> = (props) => {
             colors: {
                 background: backgroundColorLight, // input background
                 // disabled: fullTheme.colors.disabled, // disabled-label disabled-outline
-                placeholder: fullTheme.colors.textPalette.secondary, // outline placeholder inactive-label
+                placeholder: fullTheme.colors.textPalette?.secondary || fullTheme.colors.text, // outline placeholder inactive-label
             },
         },
         {
             colors: {
-                primary: fullTheme.colors.primaryPalette.main,
+                primary: fullTheme.colors.primaryPalette?.main || fullTheme.colors.primary,
                 background: backgroundColorDark, // input background
                 // error: fullTheme.colors.errorPalette.dark
             },
@@ -40,9 +55,14 @@ export const ThemedTextInput: React.FC<ThemedTextInputProps> = (props) => {
     return (
         <TextInput
             {...other}
+            // @ts-ignore issue with refs on RNP input
+            ref={inputRef}
             style={props.mode !== 'outlined' ? [{ backgroundColor }, style] : style}
             outlineColor={props.outlineColor || fullTheme.colors.divider}
             theme={theme}
         />
     );
 };
+// Necessary to allow use of ref (to pass focus to next TextInput on submit)
+export const ThemedTextInput = React.forwardRef(ThemedTextInputRender);
+TextInput.displayName = 'ThemedTextInput';

--- a/components/src/themed/ThemedToggleButton.tsx
+++ b/components/src/themed/ThemedToggleButton.tsx
@@ -61,19 +61,21 @@ const ThemedToggleButtonComponent: React.FC<ThemedToggleButtonProps> = (props) =
 
                 const backgroundColor = fullTheme.dark
                     ? checked
-                        ? Color(fullTheme.colors.primaryPalette.dark).alpha(0.36).string()
+                        ? Color(fullTheme.colors.primaryPalette?.dark || fullTheme.colors.primary)
+                              .alpha(0.36)
+                              .string()
                         : fullTheme.colors.surface
                     : checked
-                    ? fullTheme.colors.primaryPalette.light
+                    ? fullTheme.colors.primaryPalette?.light || Color(fullTheme.colors.primary).alpha(0.05).toString()
                     : fullTheme.colors.surface;
 
                 const textColor = fullTheme.dark
                     ? checked
-                        ? fullTheme.colors.primaryPalette.main
+                        ? fullTheme.colors.primaryPalette?.main || fullTheme.colors.primary
                         : fullTheme.colors.placeholder
                     : checked
-                    ? fullTheme.colors.primaryPalette.main
-                    : fullTheme.colors.textPalette.secondary;
+                    ? fullTheme.colors.primaryPalette?.main || fullTheme.colors.primary
+                    : fullTheme.colors.textPalette?.secondary || fullTheme.colors.text;
 
                 return (
                     <ToggleButton

--- a/components/src/themed/hooks/useAlternateTheme.tsx
+++ b/components/src/themed/hooks/useAlternateTheme.tsx
@@ -20,10 +20,10 @@ export const useAlternateTheme = (
     const altDarkTheme: $DeepPartial<ReactNativePaper.Theme> = merge.all([
         {
             colors: {
-                primary: theme.colors.primaryPalette.dark,
-                accent: theme.colors.accentPalette.dark,
+                primary: theme.colors?.primaryPalette?.dark || theme.colors.primary,
+                accent: theme.colors?.accentPalette?.dark || theme.colors.accent,
                 background: theme.colors.surface,
-                notification: theme.colors.accentPalette.dark,
+                notification: theme.colors?.accentPalette?.dark || theme.colors.notification,
             },
         },
         extraDark || {},

--- a/demos/storybook/ios/Podfile.lock
+++ b/demos/storybook/ios/Podfile.lock
@@ -469,7 +469,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 1220a6adc1019bd43bedf9754bda4578046b8f1a
+  FBReactNativeSpec: 77a75222a6c2468ce76a6968799bbc913bad9398
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c
@@ -512,4 +512,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f2fe0833bd18e5e6697b13280acacc76a7a2ceb4
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.10.1

--- a/demos/storybook/ios/storybook.xcodeproj/project.pbxproj
+++ b/demos/storybook/ios/storybook.xcodeproj/project.pbxproj
@@ -493,7 +493,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-storybook/Pods-storybook-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -585,7 +585,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-storybook-storybookTests/Pods-storybook-storybookTests-frameworks.sh",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -31,7 +31,7 @@ import { ChannelValue } from '@pxblue/react-native-components';
 
 </div>
 
-> *Setting `unitSpace` to `'auto'` will show a space for all units except for '%', '℉', '°F', '℃', '°C', and '°'. When `prefix` is true, the space will be shown for all units except for '$'.
+> \*Setting `unitSpace` to `'auto'` will show a space for all units except for '%', '℉', '°F', '℃', '°C', and '°'. When `prefix` is true, the space will be shown for all units except for '$'.
 
 ### Styles
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #213 
Fixes #214

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add fallback colors for Themed Components
- Add ref Forwarding to Themed Text Input

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Publish a new beta version with these changes
- Install the beta into the feature branch for fixes in the workflow: https://github.com/pxblue/react-native-workflows/pull/95
- See if the tests in that branch pass and no yellow box warning is thrown on the app 
    - You should also be able to navigate between text fields by using the software keyboard Next button 


I haven't actually tested any of these changes myself...I just did the heavy lifting.