### PR TITLE
Add husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+cd ./components && yarn prettier:check && yarn lint && yarn coverage & cd ..

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-cd ./components && yarn prettier:check && yarn lint && yarn coverage & cd ..
+cd ./components && yarn && yarn prettier:check && yarn lint && yarn coverage & cd ..

--- a/components/jest.config.js
+++ b/components/jest.config.js
@@ -9,6 +9,11 @@ module.exports = {
         '^.+\\.tsx?$': 'ts-jest',
     },
     collectCoverage: true,
+    coverageThreshold: {
+        "global": {
+          "lines": 75
+        }
+      },
     coverageReporters: ['text', 'cobertura'],
     transformIgnorePatterns: [
         'node_modules/(?!(react-native|@react-native/*|react-native-vector-icons|react-native-animatable|react-native-reanimated|react-native-iphone-x-helper|react-native-modal|react-native-collapsible|@react-native/polyfills)/)',

--- a/package.json
+++ b/package.json
@@ -1,51 +1,54 @@
 {
-    "name": "react-native-components",
-    "version": "0.0.0",
-    "scripts": {
-        "initialize": "bash scripts/initializeSubmodule.sh",
-        "build": "bash ./scripts/buildComponents.sh",
-        "install:showcase-ios": "yarn initialize && cd demos/showcase && yarn && cd ios && pod install && cd ../../.. && yarn link:components",
-        "install:showcase-android": "yarn initialize && cd demos/showcase && yarn && cd ../.. && yarn link:components",
-        "install:storybook-ios": "cd demos/storybook && yarn && cd ios && pod install && cd ../../.. && yarn link:components",
-        "install:storybook-android": "cd demos/storybook && yarn && cd ../.. && yarn link:components",
-        "install:storybook-api": "cd demos/api && yarn && cd ../.. && yarn link:components",
-        "install:all": "yarn && cd components && yarn install && cd .. && yarn install:showcase-ios && yarn install:storybook-ios && yarn install:storybook-api",
-        "install:all-android": "cd components && yarn install && cd .. && yarn install:showcase-android && yarn install:storybook-android && yarn install:storybook-api",
-        "link:components": "bash ./scripts/linkComponents.sh",
-        "publish:package": "cd dist && rm -f *.tgz && set npm_config_yes=true && npx -p @brightlayer-ui/publish blui-publish",
-        "tag:package": "cd dist && set npm_config_yes=true && npx -p @brightlayer-ui/tag blui-tag -s -blui-react-native-component-library",
-        "start": "yarn start:showcase",
-        "start:showcase": "yarn start:showcase-ios",
-        "start:showcase-ios": "yarn install:showcase-ios && cd demos/showcase && yarn ios",
-        "start:showcase-android": "yarn install:showcase-android && cd demos/showcase && yarn android",
-        "start:storybook": "yarn start:storybook-ios",
-        "start:storybook-ios": "yarn install:storybook-ios && cd demos/storybook && yarn ios",
-        "start:storybook-android": "yarn install:storybook-android && cd demos/storybook && yarn android",
-        "start:storybook-api": "yarn install:storybook-api && cd demos/api && yarn start",
-        "test": "cd components && yarn test",
-        "test:watch": "cd components && yarn test:watch",
-        "test:artifacts": "echo \"TODO: TEST ARTIFACTS\"",
-        "prettier": "prettier \"docs/**.{ts,tsx,js,jsx,json,css,scss,md,html}\" --write && cd components && yarn prettier && cd ../demos/api && yarn prettier  && cd ../storybook && yarn prettier",
-        "prettier:check": "prettier \"docs/**.{ts,tsx,js,jsx,json,css,scss,md,html}\" --check && cd components && yarn prettier:check && cd ../demos/api && yarn prettier:check && cd ../storybook && yarn prettier:check",
-        "lint": "cd components && yarn lint && cd ../demos/api && yarn lint && cd ../storybook && yarn lint",
-        "lint:fix": "cd components && yarn lint:fix && cd ../demos/api && yarn lint:fix && cd ../storybook && yarn lint:fix",
-        "update:submodule": "git submodule update --remote",
-        "precommit": "yarn install:all && yarn prettier && yarn lint && yarn test && yarn build && yarn test:artifacts && yarn generate:licenses",
-        "coverage": "cd components && yarn test --coverage --watchAll=false",
-        "generate:licenses": "cd ./components && npm-license-crawler -onlyDirectDependencies -json LICENSES.json"
-    },
-    "directories": {
-        "doc": "docs"
-    },
-    "prettier": "@brightlayer-ui/prettier-config",
-    "devDependencies": {
-        "@brightlayer-ui/prettier-config": "^1.0.3",
-        "eslint-plugin-react-hooks": "^4.6.2",
-        "npm-license-crawler": "^0.2.1",
-        "prettier": "^3.3.3"
-    },
-    "jest": {
-        "coverageDirectory": "./components/coverage/",
-        "collectCoverage": true
-    }
+  "name": "react-native-components",
+  "version": "0.0.0",
+  "scripts": {
+    "initialize": "bash scripts/initializeSubmodule.sh",
+    "build": "bash ./scripts/buildComponents.sh",
+    "install:showcase-ios": "yarn initialize && cd demos/showcase && yarn && cd ios && pod install && cd ../../.. && yarn link:components",
+    "install:showcase-android": "yarn initialize && cd demos/showcase && yarn && cd ../.. && yarn link:components",
+    "install:storybook-ios": "cd demos/storybook && yarn && cd ios && pod install && cd ../../.. && yarn link:components",
+    "install:storybook-android": "cd demos/storybook && yarn && cd ../.. && yarn link:components",
+    "install:storybook-api": "cd demos/api && yarn && cd ../.. && yarn link:components",
+    "install:all": "yarn && cd components && yarn install && cd .. && yarn install:showcase-ios && yarn install:storybook-ios && yarn install:storybook-api",
+    "install:components": "yarn && cd components && yarn",
+    "install:all-android": "cd components && yarn install && cd .. && yarn install:showcase-android && yarn install:storybook-android && yarn install:storybook-api",
+    "link:components": "bash ./scripts/linkComponents.sh",
+    "publish:package": "cd dist && rm -f *.tgz && set npm_config_yes=true && npx -p @brightlayer-ui/publish blui-publish",
+    "tag:package": "cd dist && set npm_config_yes=true && npx -p @brightlayer-ui/tag blui-tag -s -blui-react-native-component-library",
+    "start": "yarn start:showcase",
+    "start:showcase": "yarn start:showcase-ios",
+    "start:showcase-ios": "yarn install:showcase-ios && cd demos/showcase && yarn ios",
+    "start:showcase-android": "yarn install:showcase-android && cd demos/showcase && yarn android",
+    "start:storybook": "yarn start:storybook-ios",
+    "start:storybook-ios": "yarn install:storybook-ios && cd demos/storybook && yarn ios",
+    "start:storybook-android": "yarn install:storybook-android && cd demos/storybook && yarn android",
+    "start:storybook-api": "yarn install:storybook-api && cd demos/api && yarn start",
+    "test": "cd components && yarn test",
+    "test:watch": "cd components && yarn test:watch",
+    "test:artifacts": "echo \"TODO: TEST ARTIFACTS\"",
+    "prettier": "prettier \"docs/**.{ts,tsx,js,jsx,json,css,scss,md,html}\" --write && cd components && yarn prettier",
+    "prettier:check": "prettier \"docs/**.{ts,tsx,js,jsx,json,css,scss,md,html}\" --check && cd components && yarn prettier:check",
+    "lint": "cd components && yarn lint",
+    "lint:fix": "cd components && yarn lint:fix",
+    "update:submodule": "git submodule update --remote",
+    "precommit": "yarn install:all && yarn prettier && yarn lint && yarn test && yarn build && yarn test:artifacts && yarn generate:licenses",
+    "coverage": "cd components && yarn test --coverage --watchAll=false",
+    "generate:licenses": "cd ./components && npm-license-crawler -onlyDirectDependencies -json LICENSES.json",
+    "prepare": "husky"
+  },
+  "directories": {
+    "doc": "docs"
+  },
+  "prettier": "@brightlayer-ui/prettier-config",
+  "devDependencies": {
+    "@brightlayer-ui/prettier-config": "^1.0.3",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "husky": "^9.1.6",
+    "npm-license-crawler": "^0.2.1",
+    "prettier": "^3.3.3"
+  },
+  "jest": {
+    "coverageDirectory": "./components/coverage/",
+    "collectCoverage": true
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,6 +159,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
+husky@^9.1.6:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
+  integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes BLUI-6037.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- added husky with pre-commit
- set jest config to include coverage thresholds
- pre-commit will run `cd ./components && yarn && yarn prettier:check && yarn lint && yarn coverage`

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-

https://github.com/user-attachments/assets/ec404a47-741d-4eda-83ff-afc16ec80fcc



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- clone fresh copy `git clone https://github.com/etn-ccis/blui-react-native-component-library.git`
- `git checkout feature/blui-6037-husky-pre-commit-hook`
- run `yarn install:components`
- make a change somewhere to generate change set (readme)
- depending on your normal commits

a.) use the vs code source control panel to stage and commit. 
(the husky pre-commit runs in the background and when complete your commit will compete)

OR

b.) use the terminal `git add . && git commit -m 'my commit'` (running in terminal will display what pre-commit runs)

***Next test***
- edit the jest.config file in components directory and update line 14 to be `"lines": 76`
- make additional change in readme
- repeat step (a) from above and when vs code modal opens select open git log.

OR

- repeat step (b) from above and view output

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


